### PR TITLE
Fix typo in 'confirm new vault password' message

### DIFF
--- a/changelogs/fragments/48730-zabbix_hostmacro-fixes.yaml
+++ b/changelogs/fragments/48730-zabbix_hostmacro-fixes.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - zabbix_hostmacro - Added missing validate_certs logic for running module against Zabbix servers with untrused SSL certificates (https://github.com/ansible/ansible/issues/47611)
+  - zabbix_hostmacro - Fixed support for user macros with context (https://github.com/ansible/ansible/issues/46953)

--- a/changelogs/fragments/48936-import-handlers.yaml
+++ b/changelogs/fragments/48936-import-handlers.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+- imports - Prevent the name of an import from being addressable as a handler, only the tasks within should
+  be addressable. Use an include instead of an import if you need to execute many tasks from a single handler
+  (https://github.com/ansible/ansible/issues/48936)

--- a/changelogs/fragments/49188-zabbix_template-fix-idempotency.yaml
+++ b/changelogs/fragments/49188-zabbix_template-fix-idempotency.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - zabbix_template - Fixed idempotency of the module when using ``link_templates``, ``macros`` or ``template_json`` options (https://github.com/ansible/ansible/issues/48337)

--- a/docs/docsite/rst/plugins/action.rst
+++ b/docs/docsite/rst/plugins/action.rst
@@ -1,3 +1,5 @@
+.. _action_plugins:
+
 Action Plugins
 ==============
 
@@ -12,19 +14,19 @@ The 'normal' action plugin is used for modules that do not already have an actio
 
 .. _enabling_action:
 
-Enabling Action Plugins
+Enabling action plugins
 -----------------------
 
 You can enable a custom action plugin by either dropping it into the ``action_plugins`` directory adjacent to your play, inside a role, or by putting it in one of the action plugin directory sources configured in :ref:`ansible.cfg <ansible_configuration_settings>`.
 
 .. _using_action:
 
-Using Action Plugins
+Using action plugins
 --------------------
 
 Action plugin are executed by default when an associated module is used; no action is required.
 
-Plugin List
+Plugin list
 -----------
 
 You cannot list action plugins directly, they show up as their counterpart modules:
@@ -34,19 +36,19 @@ Use ``ansible-doc <name>`` to see specific documentation and examples, this shou
 
 .. seealso::
 
-   :doc:`cache`
+   :ref:`cache_plugins`
        Ansible Cache plugins
-   :doc:`callback`
+   :ref:`callback_plugins`
        Ansible callback plugins
-   :doc:`connection`
+   :ref:`connection_plugins`
        Ansible connection plugins
-   :doc:`inventory`
+   :ref:`inventory_plugins`
        Ansible inventory plugins
-   :doc:`shell`
+   :ref:`shell_plugins`
        Ansible Shell plugins
-   :doc:`strategy`
+   :ref:`strategy_plugins`
        Ansible Strategy plugins
-   :doc:`vars`
+   :ref:`vars_plugins`
        Ansible Vars plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/plugins/action.rst
+++ b/docs/docsite/rst/plugins/action.rst
@@ -27,8 +27,10 @@ Action plugin are executed by default when an associated module is used; no acti
 Plugin List
 -----------
 
-You can use ``ansible-doc -t action -l`` to see the list of available plugins.
-Use ``ansible-doc -t action <plugin name>`` to see specific documentation and examples.
+You cannot list action plugins directly, they show up as their counterpart modules:
+
+Use ``ansible-doc -l`` to see the list of available modules.
+Use ``ansible-doc <name>`` to see specific documentation and examples, this should note if the module has a corresponding action plugin.
 
 .. seealso::
 

--- a/docs/docsite/rst/plugins/cache.rst
+++ b/docs/docsite/rst/plugins/cache.rst
@@ -1,13 +1,16 @@
-.. contents:: Topics
-
+.. _cache_plugins:
 
 Cache Plugins
 =============
 
+.. contents::
+   :local:
+   :depth: 2
+
 Cache plugin implement a backend caching mechanism that allows Ansible to store gathered facts or inventory source data
 without the performance hit of retrieving them from source.
 
-The default cache plugin is the :doc:`memory <cache/memory>` plugin, which only caches the data for the current execution of Ansible. Other plugins with persistent storage are available to allow caching the data across runs.
+The default cache plugin is the :ref:`memory <memory_cache>` plugin, which only caches the data for the current execution of Ansible. Other plugins with persistent storage are available to allow caching the data across runs.
 
 You can use a separate cache plugin for inventory and facts. If an inventory-specific cache plugin is not provided and inventory caching is enabled, the fact cache plugin is used for inventory.
 
@@ -110,19 +113,19 @@ Use ``ansible-doc -t cache <plugin name>`` to see specific documentation and exa
 
 .. seealso::
 
-   :doc:`action`
+   :ref:`action_plugins`
        Ansible Action plugins
-   :doc:`callback`
+   :ref:`callback_plugins`
        Ansible callback plugins
-   :doc:`connection`
+   :ref:`connection_plugins`
        Ansible connection plugins
-   :doc:`inventory`
+   :ref:`inventory_plugins`
        Ansible inventory plugins
-   :doc:`shell`
+   :ref:`shell_plugins`
        Ansible Shell plugins
-   :doc:`strategy`
+   :ref:`strategy_plugins`
        Ansible Strategy plugins
-   :doc:`vars`
+   :ref:`vars_plugins`
        Ansible Vars plugins
    `User Mailing List <https://groups.google.com/forum/#!forum/ansible-devel>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/plugins/callback.rst
+++ b/docs/docsite/rst/plugins/callback.rst
@@ -1,8 +1,11 @@
-.. contents:: Topics
-
+.. _callback_plugins:
 
 Callback Plugins
-----------------
+================
+
+.. contents::
+   :local:
+   :depth: 2
 
 Callback plugins enable adding new behaviors to Ansible when responding to events.
 By default, callback plugins control most of the output you see when running the command line programs,
@@ -10,19 +13,18 @@ but can also be used to add additional output, integrate with other tools and ma
 
 .. _callback_examples:
 
-Example Callback Plugins
-++++++++++++++++++++++++
+Example callback plugins
+------------------------
 
-The :doc:`log_plays <callback/log_plays>` callback is an example of how to record playbook events to a log file,
-and the :doc:`mail <callback/mail>` callback sends email on playbook failures.
+The :ref:`log_plays <log_plays_callback>` callback is an example of how to record playbook events to a log file,
+and the :ref:`mail <mail_callback>` callback sends email on playbook failures.
 
-The :doc:`osx_say <callback/osx_say>` callback responds with computer synthesized speech on macOS in relation to playbook events.
-
+The :ref:`osx_say <osx_say_callback>` callback responds with computer synthesized speech on macOS in relation to playbook events.
 
 .. _enabling_callbacks:
 
-Enabling Callback Plugins
-++++++++++++++++++++++++++
+Enabling callback plugins
+-------------------------
 
 You can activate a custom callback by either dropping it into a ``callback_plugins`` directory adjacent to your play,  inside a role, or by putting it in one of the callback directory sources configured in :ref:`ansible.cfg <ansible_configuration_settings>`.
 
@@ -34,9 +36,8 @@ Most callbacks shipped with Ansible are disabled by default and need to be white
 
   #callback_whitelist = timer, mail, profile_roles
 
-
-Managing stdout
-```````````````
+Setting a callback plugin for ``ansible-playbook``
+--------------------------------------------------
 
 You can only have one plugin be the main manager of your console output. If you want to replace the default, you should define CALLBACK_TYPE = stdout in the subclass and then configure the stdout plugin in :ref:`ansible.cfg <ansible_configuration_settings>`. For example:
 
@@ -52,8 +53,8 @@ or for my custom callback:
 
 This only affects :ref:`ansible-playbook` by default.
 
-Managing AdHoc
-``````````````
+Setting a callback plugin for ad-hoc commands
+---------------------------------------------
 
 The :ref:`ansible` ad hoc command specifically uses a different callback plugin for stdout,
 so there is an extra setting in :ref:`ansible_configuration_settings` you need to add to use the stdout callback defined above:
@@ -72,12 +73,11 @@ You can also set this as an environment variable:
 
 .. _callback_plugin_list:
 
-Plugin List
-+++++++++++
+Plugin list
+-----------
 
 You can use ``ansible-doc -t callback -l`` to see the list of available plugins.
 Use ``ansible-doc -t callback <plugin name>`` to see specific documents and examples.
-
 
 .. toctree:: :maxdepth: 1
     :glob:
@@ -87,19 +87,19 @@ Use ``ansible-doc -t callback <plugin name>`` to see specific documents and exam
 
 .. seealso::
 
-   :doc:`action`
+   :ref:`action_plugins`
        Ansible Action plugins
-   :doc:`cache`
+   :ref:`cache_plugins`
        Ansible cache plugins
-   :doc:`connection`
+   :ref:`connection_plugins`
        Ansible connection plugins
-   :doc:`inventory`
+   :ref:`inventory_plugins`
        Ansible inventory plugins
-   :doc:`shell`
+   :ref:`shell_plugins`
        Ansible Shell plugins
-   :doc:`strategy`
+   :ref:`strategy_plugins`
        Ansible Strategy plugins
-   :doc:`vars`
+   :ref:`vars_plugins`
        Ansible Vars plugins
    `User Mailing List <https://groups.google.com/forum/#!forum/ansible-devel>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/plugins/connection.rst
+++ b/docs/docsite/rst/plugins/connection.rst
@@ -1,7 +1,11 @@
-.. contents:: Topics
+.. _connection_plugins:
 
 Connection Plugins
-------------------
+==================
+
+.. contents::
+   :local:
+   :depth: 2
 
 Connection plugins allow Ansible to connect to the target hosts so it can execute tasks on them. Ansible ships with many connection plugins, but only one can be used per host at a time.
 
@@ -11,28 +15,28 @@ The basics of these connection types are covered in the :ref:`getting started<in
 
 .. _ssh_plugins:
 
-ssh Plugins
-+++++++++++
+``ssh`` plugins
+---------------
 
 Because ssh is the default protocol used in system administration and the protocol most used in Ansible, ssh options are included in the command line tools. See :ref:`ansible-playbook` for more details.
 
 .. _enabling_connection:
 
-Enabling Connection Plugins
-+++++++++++++++++++++++++++
+Adding connection plugins
+-------------------------
 
 You can extend Ansible to support other transports (such as SNMP or message bus) by dropping a custom plugin
 into the ``connection_plugins`` directory.
 
 .. _using_connection:
 
-Using Connection Plugins
-++++++++++++++++++++++++
+Using connection plugins
+------------------------
 
-The transport can be changed via :ref:`configuration<ansible_configuration_settings>`, at the command line (``-c``, ``--connection``), as a :ref:`keyword <playbook_keywords>` in your play, or by setting a :ref:`variable<behavioral_parameters>`, most often in your inventory.
-For example, for Windows machines you might want to use the :doc:`winrm<connection/winrm>` plugin.
+You can set the connection plugin globally via :ref:`configuration<ansible_configuration_settings>`, at the command line (``-c``, ``--connection``), as a :ref:`keyword <playbook_keywords>` in your play, or by setting a :ref:`variable<behavioral_parameters>`, most often in your inventory.
+For example, for Windows machines you might want to set the :ref:`winrm <winrm_connection>` plugin as an inventory variable.
 
-Most connection plugins can operate with a minimum configuration. By default they use the :ref:`inventory hostname<inventory_hostnames_lookup>` and defaults to find the target host.
+Most connection plugins can operate with minimal configuration. By default they use the :ref:`inventory hostname<inventory_hostnames_lookup>` and defaults to find the target host.
 
 Plugins are self-documenting. Each plugin should document its configuration options. The following are connection variables common to most connection plugins:
 
@@ -48,7 +52,7 @@ Each plugin might also have a specific version of a variable that overrides the 
 .. _connection_plugin_list:
 
 Plugin List
-+++++++++++
+-----------
 
 You can use ``ansible-doc -t connection -l`` to see the list of available plugins.
 Use ``ansible-doc -t connection <plugin name>`` to see detailed documentation and examples.
@@ -64,7 +68,7 @@ Use ``ansible-doc -t connection <plugin name>`` to see detailed documentation an
 
    :ref:`Working with Playbooks<working_with_playbooks>`
        An introduction to playbooks
-   :doc:`callback`
+   :ref:`callback_plugins`
        Ansible callback plugins
    :ref:`Filters<playbooks_filters>`
        Jinja2 filter plugins
@@ -72,7 +76,7 @@ Use ``ansible-doc -t connection <plugin name>`` to see detailed documentation an
        Jinja2 test plugins
    :ref:`Lookups<playbooks_lookups>`
        Jinja2 lookup plugins
-   :doc:`vars`
+   :ref:`vars_plugins`
        Ansible vars plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -1,16 +1,18 @@
-.. contents:: Topics
-
 .. _inventory_plugins:
 
 Inventory Plugins
 =================
+
+.. contents::
+   :local:
+   :depth: 2
 
 Inventory plugins allow users to point at data sources to compile the inventory of hosts that Ansible uses to target tasks, either via the ``-i /path/to/file`` and/or ``-i 'host1, host2'`` command line parameters or from other configuration sources.
 
 
 .. _enabling_inventory:
 
-Enabling Inventory Plugins
+Enabling inventory plugins
 --------------------------
 
 Most inventory plugins shipped with Ansible are disabled by default and need to be whitelisted in your
@@ -32,7 +34,7 @@ This list also establishes the order in which each plugin tries to parse an inve
 
 .. _using_inventory:
 
-Using Inventory Plugins
+Using inventory plugins
 -----------------------
 
 The only requirement for using an inventory plugin after it is enabled is to provide an inventory source to parse.
@@ -109,7 +111,7 @@ If a host does not have the variables in the configuration above (i.e. ``tags.Na
 Plugin List
 -----------
 
-You can use ``ansible-doc -t inventory -l`` to see the list of available plugins. 
+You can use ``ansible-doc -t inventory -l`` to see the list of available plugins.
 Use ``ansible-doc -t inventory <plugin name>`` to see plugin-specific documentation and examples.
 
 .. toctree:: :maxdepth: 1
@@ -121,9 +123,9 @@ Use ``ansible-doc -t inventory <plugin name>`` to see plugin-specific documentat
 
    :ref:`about_playbooks`
        An introduction to playbooks
-   :doc:`callback`
+   :ref:`callback_plugins`
        Ansible callback plugins
-   :doc:`connection`
+   :ref:`connection_plugins`
        Ansible connection plugins
    :ref:`playbooks_filters`
        Jinja2 filter plugins
@@ -131,7 +133,7 @@ Use ``ansible-doc -t inventory <plugin name>`` to see plugin-specific documentat
        Jinja2 test plugins
    :ref:`playbooks_lookups`
        Jinja2 lookup plugins
-   :doc:`vars`
+   :ref:`vars_plugins`
        Ansible vars plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/plugins/lookup.rst
+++ b/docs/docsite/rst/plugins/lookup.rst
@@ -1,9 +1,11 @@
-.. contents:: Topics
-
 .. _lookup_plugins:
 
 Lookup Plugins
---------------
+==============
+
+.. contents::
+   :local:
+   :depth: 2
 
 Lookup plugins allow Ansible to access data from outside sources.
 This can include reading the filesystem in addition to contacting external datastores and services.
@@ -26,16 +28,16 @@ Lookups are an Ansible-specific extension to the Jinja2 templating language.
 
 .. _enabling_lookup:
 
-Enabling Lookup Plugins
-+++++++++++++++++++++++
+Enabling lookup plugins
+-----------------------
 
 You can activate a custom lookup by either dropping it into a ``lookup_plugins`` directory adjacent to your play, inside a role, or by putting it in one of the lookup directory sources configured in :ref:`ansible.cfg <ansible_configuration_settings>`.
 
 
 .. _using_lookup:
 
-Using Lookup Plugins
-++++++++++++++++++++
+Using lookup plugins
+--------------------
 
 Lookup plugins can be used anywhere you can use templating in Ansible: in a play, in variables file, or in a Jinja2 template for the :ref:`template <template_module>` module.
 
@@ -45,7 +47,7 @@ Lookup plugins can be used anywhere you can use templating in Ansible: in a play
     file_contents: "{{lookup('file', 'path/to/file.txt')}}"
 
 Lookups are an integral part of loops. Wherever you see ``with_``, the part after the underscore is the name of a lookup.
-This is also the reason most lookups output lists and take lists as input; for example, ``with_items`` uses the :doc:`items <lookup/items>` lookup:
+This is also the reason most lookups output lists and take lists as input; for example, ``with_items`` uses the :ref:`items <items_lookup>` lookup:
 
 .. code-block:: yaml
 
@@ -108,15 +110,15 @@ Fatal error (the default)::
 
 .. _query:
 
-query
-+++++
+Invoking lookup plugins with ``query``
+--------------------------------------
 
 .. versionadded:: 2.5
 
 In Ansible 2.5, a new jinja2 function called ``query`` was added for invoking lookup plugins. The difference between ``lookup`` and ``query`` is largely that ``query`` will always return a list.
 The default behavior of ``lookup`` is to return a string of comma separated values. ``lookup`` can be explicitly configured to return a list using ``wantlist=True``.
 
-This was done primarily to provide an easier and more consistent interface for interacting with the new ``loop`` keyword, while maintaining backwards compatibiltiy with other uses of ``lookup``.
+This was done primarily to provide an easier and more consistent interface for interacting with the new ``loop`` keyword, while maintaining backwards compatibility with other uses of ``lookup``.
 
 The following examples are equivalent::
 
@@ -133,8 +135,8 @@ Additionally, ``q`` was introduced as a shortform of ``query``::
 
 .. _lookup_plugins_list:
 
-Plugin List
-+++++++++++
+Plugin list
+-----------
 
 You can use ``ansible-doc -t lookup -l`` to see the list of available plugins. Use ``ansible-doc -t lookup <plugin name>`` to see specific documents and examples.
 
@@ -148,9 +150,9 @@ You can use ``ansible-doc -t lookup -l`` to see the list of available plugins. U
 
    :ref:`about_playbooks`
        An introduction to playbooks
-   :doc:`inventory`
+   :ref:`inventory_plugins`
        Ansible inventory plugins
-   :doc:`callback`
+   :ref:`callback_plugins`
        Ansible callback plugins
    :ref:`playbooks_filters`
        Jinja2 filter plugins

--- a/docs/docsite/rst/plugins/plugins.rst
+++ b/docs/docsite/rst/plugins/plugins.rst
@@ -10,7 +10,7 @@ Ansible ships with a number of handy plugins, and you can easily write your own.
 
 This section covers the various types of plugins that are included with Ansible:
 
-.. toctree:: 
+.. toctree::
    :maxdepth: 1
 
    action
@@ -32,7 +32,7 @@ This section covers the various types of plugins that are included with Ansible:
        An introduction to playbooks
    :ref:`ansible_configuration_settings`
        Ansible configuration documentation and settings
-   :doc:`../user_guide/command_line_tools`
+   :ref:`command_line_tools`
        Ansible tools, description and options
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/plugins/shell.rst
+++ b/docs/docsite/rst/plugins/shell.rst
@@ -1,15 +1,19 @@
-.. contents:: Topics
+.. _shell_plugins:
 
 Shell Plugins
--------------
+=============
+
+.. contents::
+   :local:
+   :depth: 2
 
 Shell plugins work to ensure that the basic commands Ansible runs are properly formatted to work with
 the target machine and allow the user to configure certain behaviors related to how Ansible executes tasks.
 
 .. _enabling_shell:
 
-Enabling Shell Plugins
-++++++++++++++++++++++
+Enabling shell plugins
+----------------------
 
 You can add a custom shell plugin by dropping it into a ``shell_plugins`` directory adjacent to your play, inside a role,
 or by putting it in one of the shell plugin directory sources configured in :ref:`ansible.cfg <ansible_configuration_settings>`.
@@ -19,8 +23,8 @@ or by putting it in one of the shell plugin directory sources configured in :ref
 
 .. _using_shell:
 
-Using Shell Plugins
-+++++++++++++++++++
+Using shell plugins
+-------------------
 
 In addition to the default configuration settings in :ref:`ansible_configuration_settings`, you can use
 the connection variable :ref:`ansible_shell_type <ansible_shell_type>` to select the plugin to use.
@@ -36,17 +40,17 @@ detailed in the plugin themselves (linked below).
 
 .. seealso::
 
-   :doc:`../user_guide/playbooks`
+   :ref:`about_playbooks`
        An introduction to playbooks
-   :doc:`inventory`
+   :ref:`inventory_plugins`
        Ansible inventory plugins
-   :doc:`callback`
+   :ref:`callback_plugins`
        Ansible callback plugins
-   :doc:`../user_guide/playbooks_filters`
+   :ref:`playbooks_filters`
        Jinja2 filter plugins
-   :doc:`../user_guide/playbooks_tests`
+   :ref:`playbooks_tests`
        Jinja2 test plugins
-   :doc:`../user_guide/playbooks_lookups`
+   :ref:`playbooks_lookups`
        Jinja2 lookup plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/plugins/strategy.rst
+++ b/docs/docsite/rst/plugins/strategy.rst
@@ -1,27 +1,29 @@
-.. contents:: Topics
-
+.. _strategy_plugins:
 
 Strategy Plugins
-----------------
+================
+
+.. contents::
+   :local:
+   :depth: 2
 
 Strategy plugins control the flow of play execution by handling task and host scheduling.
 
 .. _enable_strategy:
 
-Enabling Strategy Plugins
-+++++++++++++++++++++++++
+Enabling strategy plugins
+-------------------------
 
-Strategy plugins shipped with Ansible are enabled by default. You can enable a custom strategy plugin by
+All strategy plugins shipped with Ansible are enabled by default. You can enable a custom strategy plugin by
 putting it in one of the lookup directory sources configured in :ref:`ansible.cfg <ansible_configuration_settings>`.
-
 
 .. _using_strategy:
 
-Using Strategy Plugins
-++++++++++++++++++++++
+Using strategy plugins
+----------------------
 
 Only one strategy plugin can be used in a play, but you can use different ones for each play in a playbook or ansible run.
-The default is the :doc:`linear <strategy/linear>` plugin. You can change this default in Ansible :ref:`configuration <ansible_configuration_settings>` using an environment variable:
+The default is the :ref:`linear <linear_strategy>` plugin. You can change this default in Ansible :ref:`configuration <ansible_configuration_settings>` using an environment variable:
 
 .. code-block:: shell
 
@@ -50,10 +52,10 @@ You can also specify the strategy plugin in the play via the :ref:`strategy keyw
 
 .. _strategy_plugin_list:
 
-Plugin List
-+++++++++++
+Plugin list
+-----------
 
-You can use ``ansible-doc -t strategy -l`` to see the list of available plugins. 
+You can use ``ansible-doc -t strategy -l`` to see the list of available plugins.
 Use ``ansible-doc -t strategy <plugin name>`` to see plugin-specific specific documentation and examples.
 
 
@@ -66,9 +68,9 @@ Use ``ansible-doc -t strategy <plugin name>`` to see plugin-specific specific do
 
    :ref:`about_playbooks`
        An introduction to playbooks
-   :doc:`inventory`
+   :ref:`inventory_plugins`
        Ansible inventory plugins
-   :doc:`callback`
+   :ref:`callback_plugins`
        Ansible callback plugins
    :ref:`playbooks_filters`
        Jinja2 filter plugins

--- a/docs/docsite/rst/plugins/vars.rst
+++ b/docs/docsite/rst/plugins/vars.rst
@@ -1,8 +1,11 @@
-.. contents:: Topics
-
+.. _vars_plugins:
 
 Vars Plugins
-------------
+============
+
+.. contents::
+   :local:
+   :depth: 2
 
 Vars plugins inject additional variable data into Ansible runs that did not come from an inventory source, playbook, or command line. Playbook constructs like 'host_vars' and 'group_vars' work using vars plugins.
 
@@ -13,16 +16,16 @@ The :ref:`host_group_vars <host_group_vars_vars>` plugin shipped with Ansible en
 
 .. _enable_vars:
 
-Enabling Vars Plugins
-+++++++++++++++++++++
+Enabling vars plugins
+---------------------
 
 You can activate a custom vars plugin by either dropping it into a ``vars_plugins`` directory adjacent to your play,  inside a role, or by putting it in one of the directory sources configured in :ref:`ansible.cfg <ansible_configuration_settings>`.
 
 
 .. _using_vars:
 
-Using Vars Plugins
-++++++++++++++++++
+Using vars plugins
+------------------
 
 Vars plugins are used automatically after they are enabled.
 
@@ -30,9 +33,9 @@ Vars plugins are used automatically after they are enabled.
 .. _vars_plugin_list:
 
 Plugin Lists
-++++++++++++
+------------
 
-You can use ``ansible-doc -t vars -l`` to see the list of available plugins. 
+You can use ``ansible-doc -t vars -l`` to see the list of available plugins.
 Use ``ansible-doc -t vars <plugin name>`` to see specific plugin-specific documentation and examples.
 
 
@@ -43,19 +46,19 @@ Use ``ansible-doc -t vars <plugin name>`` to see specific plugin-specific docume
 
 .. seealso::
 
-   :doc:`action`
+   :ref:`action_plugins`
        Ansible Action plugins
-   :doc:`cache`
+   :ref:`cache_plugins`
        Ansible Cache plugins
-   :doc:`callback`
+   :ref:`callback_plugins`
        Ansible callback plugins
-   :doc:`connection`
+   :ref:`connection_plugins`
        Ansible connection plugins
-   :doc:`inventory`
+   :ref:`inventory_plugins`
        Ansible inventory plugins
-   :doc:`shell`
+   :ref:`shell_plugins`
        Ansible Shell plugins
-   :doc:`strategy`
+   :ref:`strategy_plugins`
        Ansible Strategy plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -114,6 +114,10 @@ Noteworthy module changes
   a return value called ``diff`` was returned of type ``list``. To enable proper diff output, this was changed to
   type ``dict``; the original ``list`` is returned as ``diff.differences``.
 
+* The ``na_ontap_cluster_peer`` module has replaced ``source_intercluster_lif`` and ``dest_intercluster_lif`` string options with
+  ``source_intercluster_lifs`` and ``dest_intercluster_lifs`` list options
+
+
 Plugins
 =======
 

--- a/docs/docsite/rst/scenario_guides/guide_meraki.rst
+++ b/docs/docsite/rst/scenario_guides/guide_meraki.rst
@@ -37,58 +37,58 @@ Meraki modules provide a user-friendly interface to manage your Meraki environme
 
 .. code-block:: yaml
 
-	- name: Query SNMP settings
-	  meraki_snmp:
-	  	api_key: abc123
-	  	org_name: AcmeCorp
-	  	state: query
-	  delegate_to: localhost
+    - name: Query SNMP settings
+      meraki_snmp:
+        api_key: abc123
+        org_name: AcmeCorp
+        state: query
+      delegate_to: localhost
 
 Information about a particular object can be queried. For example, the `meraki_admin <meraki_admin_module>` module supports
 
 .. code-block:: yaml
 
-	- name: Gather information about Jane Doe
-	  meraki_admin:
-	  	api_key: abc123
-	  	org_name: AcmeCorp
-	  	state: query
-	  	email: janedoe@email.com
-	  delegate_to: localhost
+    - name: Gather information about Jane Doe
+      meraki_admin:
+        api_key: abc123
+        org_name: AcmeCorp
+        state: query
+        email: janedoe@email.com
+      delegate_to: localhost
 
 Common Parameters
 =================
 
 All Ansible Meraki modules support the following parameters which affect communication with the Meraki Dashboard API. Most of these should only be used by Meraki developers and not the general public.
 
-	host
-		Hostname or IP of Meraki Dashboard.
+    host
+        Hostname or IP of Meraki Dashboard.
 
-	use_https
-		Specifies whether communication should be over HTTPS. (Defaults to ``yes``)
+    use_https
+        Specifies whether communication should be over HTTPS. (Defaults to ``yes``)
 
-	use_proxy
-		Whether to use a proxy for any communication.
+    use_proxy
+        Whether to use a proxy for any communication.
 
-	validate_certs
-		Determine whether certificates should be validated or trusted. (Defaults to ``yes``)
+    validate_certs
+        Determine whether certificates should be validated or trusted. (Defaults to ``yes``)
 
 These are the common parameters which are used for most every module.
 
-	org_name
-		Name of organization to perform actions in.
+    org_name
+        Name of organization to perform actions in.
 
-	org_id
-		ID of organization to perform actions in.
+    org_id
+        ID of organization to perform actions in.
 
-	net_name
-		Name of network to perform actions in.
+    net_name
+        Name of network to perform actions in.
 
-	net_id
-		ID of network to perform actions in.
+    net_id
+        ID of network to perform actions in.
 
-	state
-		General specification of what action to take. ``query`` does lookups. ``present`` creates or edits. ``absent`` deletes.
+    state
+        General specification of what action to take. ``query`` does lookups. ``present`` creates or edits. ``absent`` deletes.
 
 .. hint:: Use the ``org_id`` and ``net_id`` parameters when possible. ``org_name`` and ``net_name`` require additional behind-the-scenes API calls to learn the ID values. ``org_id`` and ``net_id`` will perform faster. 
 
@@ -108,21 +108,82 @@ Meraki and its related Ansible modules return most information in the form of a 
 
 .. code-block:: json
 
-	[
-		{
-			"orgAccess": "full", 
-			"name": "John Doe",
-			"tags": [],
-			"networks": [],
-			"email": "john@doe.com",
-			"id": "12345677890"
-		}
-	]
+    [
+        {
+            "orgAccess": "full", 
+            "name": "John Doe",
+            "tags": [],
+            "networks": [],
+            "email": "john@doe.com",
+            "id": "12345677890"
+        }
+    ]
 
 Handling Returned Data
 ======================
 
 Since Meraki's response data uses lists instead of properly keyed dictionaries for responses, certain strategies should be used when querying data for particular information. For many situations, use the ``selectattr()`` Jinja2 function.
+
+Merging Existing and New Data
+=============================
+
+Ansible's Meraki modules do not allow for manipulating data. For example, you may need to insert a rule in the middle of a firewall ruleset. Ansible and the Meraki modules lack a way to directly merge to manipulate data. However, a playlist can use a few tasks to split the list where you need to insert a rule and then merge them together again with the new rule added. The steps involved are as follows:
+
+1. Create blank "front" and "back" lists.
+    ::
+
+        vars:
+          - front_rules: []
+          - back_rules: []
+2. Get existing firewall rules from Meraki and create a new variable.
+    ::
+
+        - name: Get firewall rules
+          meraki_mx_l3_firewall:
+            auth_key: abc123
+            org_name: YourOrg
+            net_name: YourNet
+            state: query
+          delegate_to: localhost
+          register: rules
+        - set_fact:
+            original_ruleset: '{{rules.data}}'
+3. Write the new rule. The new rule needs to be in a list so it can be merged with other lists in an upcoming step. The blank `-` puts the rule in a list so it can be merged.
+    ::
+
+        - set_fact:
+            new_rule:
+              - 
+                - comment: Block traffic to server
+                  src_cidr: 192.0.1.0/24
+                  src_port: any
+                  dst_cidr: 192.0.1.2/32
+                  dst_port: any
+                  protocol: any
+                  policy: deny
+4. Split the rules into two lists. This assumes the existing ruleset is 2 rules long.
+    ::
+
+        - set_fact:
+            front_rules: '{{front_rules + [ original_ruleset[:1] ]}}'
+        - set_fact:
+            back_rules: '{{back_rules + [ original_ruleset[1:] ]}}'
+5. Merge rules with the new rule in the middle.
+    ::
+
+        - set_fact:
+            new_ruleset: '{{front_rules + new_rule + back_rules}}'
+6. Upload new ruleset to Meraki.
+    ::
+
+        - name: Set two firewall rules
+          meraki_mx_l3_firewall:
+            auth_key: abc123
+            org_name: YourOrg
+            net_name: YourNet
+            state: present
+            rules: '{{ new_ruleset }}'
+          delegate_to: localhost
 
 Error Handling
 ==============

--- a/docs/docsite/rst/user_guide/become.rst
+++ b/docs/docsite/rst/user_guide/become.rst
@@ -341,10 +341,6 @@ delegation or accessing forbidden system calls like the WUA API. You can use
 ``become`` with the same user as ``ansible_user`` to bypass these limitations
 and run commands that are not normally accessible in a WinRM session.
 
-.. note:: Prior to Ansible 2.4, become would only work when ``ansible_winrm_transport`` was
-    set to either ``basic`` or ``credssp``, but since Ansible 2.4 become now works on
-    all transport types.
-
 Administrative Rights
 ---------------------
 
@@ -353,21 +349,106 @@ the ``runas`` become method, Ansible will attempt to run the module with the
 full privileges that are available to the remote user. If it fails to elevate
 the user token, it will continue to use the limited token during execution.
 
-Before Ansible 2.5, a token was only able to be elevated when UAC was disabled
-or the remote user had the ``SeTcbPrivilege`` assigned. This restriction has
-been lifted in Ansible 2.5 and a user that is a member of the
-``BUILTIN\Administrators`` group should have an elevated token during the
-module execution.
+A user must have the ``SeDebugPrivilege`` to run a become process with elevated
+privileges. This privilege is assigned to Administrators by default. If the
+debug privilege is not available, the become process will run with a limmited
+set of privileges and groups.
 
 To determine the type of token that Ansible was able to get, run the following
-task and check the output::
+task::
 
     - win_whoami:
       become: yes
 
-Under the ``GROUP INFORMATION`` section, the ``Mandatory Label`` entry
-determines whether the user has Administrative rights. Here are the labels that
-can be returned and what they mean:
+The output will look something similar to the below::
+
+    ok: [windows] => {
+        "account": {
+            "account_name": "vagrant-domain",
+            "domain_name": "DOMAIN",
+            "sid": "S-1-5-21-3088887838-4058132883-1884671576-1105",
+            "type": "User"
+        },
+        "authentication_package": "Kerberos",
+        "changed": false,
+        "dns_domain_name": "DOMAIN.LOCAL",
+        "groups": [
+            {
+                "account_name": "Administrators",
+                "attributes": [
+                    "Mandatory",
+                    "Enabled by default",
+                    "Enabled",
+                    "Owner"
+                ],
+                "domain_name": "BUILTIN",
+                "sid": "S-1-5-32-544",
+                "type": "Alias"
+            },
+            {
+                "account_name": "INTERACTIVE",
+                "attributes": [
+                    "Mandatory",
+                    "Enabled by default",
+                    "Enabled"
+                ],
+                "domain_name": "NT AUTHORITY",
+                "sid": "S-1-5-4",
+                "type": "WellKnownGroup"
+            },
+        ],
+        "impersonation_level": "SecurityAnonymous",
+        "label": {
+            "account_name": "High Mandatory Level",
+            "domain_name": "Mandatory Label",
+            "sid": "S-1-16-12288",
+            "type": "Label"
+        },
+        "login_domain": "DOMAIN",
+        "login_time": "2018-11-18T20:35:01.9696884+00:00",
+        "logon_id": 114196830,
+        "logon_server": "DC01",
+        "logon_type": "Interactive",
+        "privileges": {
+            "SeBackupPrivilege": "disabled",
+            "SeChangeNotifyPrivilege": "enabled-by-default",
+            "SeCreateGlobalPrivilege": "enabled-by-default",
+            "SeCreatePagefilePrivilege": "disabled",
+            "SeCreateSymbolicLinkPrivilege": "disabled",
+            "SeDebugPrivilege": "enabled",
+            "SeDelegateSessionUserImpersonatePrivilege": "disabled",
+            "SeImpersonatePrivilege": "enabled-by-default",
+            "SeIncreaseBasePriorityPrivilege": "disabled",
+            "SeIncreaseQuotaPrivilege": "disabled",
+            "SeIncreaseWorkingSetPrivilege": "disabled",
+            "SeLoadDriverPrivilege": "disabled",
+            "SeManageVolumePrivilege": "disabled",
+            "SeProfileSingleProcessPrivilege": "disabled",
+            "SeRemoteShutdownPrivilege": "disabled",
+            "SeRestorePrivilege": "disabled",
+            "SeSecurityPrivilege": "disabled",
+            "SeShutdownPrivilege": "disabled",
+            "SeSystemEnvironmentPrivilege": "disabled",
+            "SeSystemProfilePrivilege": "disabled",
+            "SeSystemtimePrivilege": "disabled",
+            "SeTakeOwnershipPrivilege": "disabled",
+            "SeTimeZonePrivilege": "disabled",
+            "SeUndockPrivilege": "disabled"
+        },
+        "rights": [
+            "SeNetworkLogonRight",
+            "SeBatchLogonRight",
+            "SeInteractiveLogonRight",
+            "SeRemoteInteractiveLogonRight"
+        ],
+        "token_type": "TokenPrimary",
+        "upn": "vagrant-domain@DOMAIN.LOCAL",
+        "user_flags": []
+    }
+
+Under the ``label`` key, the ``account_name`` entry determines whether the user
+has Administrative rights. Here are the labels that can be returned and what
+they represent:
 
 * ``Medium``: Ansible failed to get an elevated token and ran under a limited
   token. Only a subset of the privileges assigned to user are available during
@@ -380,9 +461,9 @@ can be returned and what they mean:
   level of privileges available.
 
 The output will also show the list of privileges that have been granted to the
-user. When ``State==Disabled``, the privileges have not been enabled but can be
-if required. In most scenarios these privileges are automatically enabled when
-required.
+user. When the privilege value is ``disabled``, the privilege is assigned to
+the logon token but has not been enabled. In most scenarios these privileges
+are automatically enabled when required.
 
 If running on a version of Ansible that is older than 2.5 or the normal
 ``runas`` escalation process fails, an elevated token can be retrieved by:

--- a/docs/docsite/rst/user_guide/command_line_tools.rst
+++ b/docs/docsite/rst/user_guide/command_line_tools.rst
@@ -1,10 +1,12 @@
+.. _command_line_tools:
+
 Working with Command Line Tools
 ===============================
 
 Most users are familiar with `ansible` and `ansible-playbook`, but those are not the only utilities Ansible provides.
-Below is a complete list of Ansible utilities. Each page contains a description of the utility and a listing of supported parameters.	
+Below is a complete list of Ansible utilities. Each page contains a description of the utility and a listing of supported parameters.
 
-.. toctree:: 
+.. toctree::
    :maxdepth: 1
 
    ../cli/ansible.rst
@@ -16,4 +18,3 @@ Below is a complete list of Ansible utilities. Each page contains a description 
    ../cli/ansible-playbook.rst
    ../cli/ansible-pull.rst
    ../cli/ansible-vault.rst
-   

--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -1,11 +1,12 @@
 .. _intro_inventory:
 .. _inventory:
 
-
+**********************
 Working with Inventory
-======================
+**********************
 
-.. contents:: Topics
+.. contents::
+   :local:
 
 Ansible works against multiple systems in your infrastructure at the same time.
 It does this by selecting portions of systems listed in Ansible's inventory,
@@ -18,8 +19,8 @@ Introduced in version 2.4, Ansible has inventory plugins to make this flexible a
 
 .. _inventoryformat:
 
-Hosts and Groups
-++++++++++++++++
+Inventory basics: hosts and groups
+==================================
 
 The inventory file can be in one of many formats, depending on the inventory plugins you have.
 For this example, the format for ``/etc/ansible/hosts`` is an INI-like (one of Ansible's defaults) and looks like this:
@@ -129,8 +130,8 @@ As mentioned above, setting these in the inventory file is only a shorthand, and
 
 .. _host_variables:
 
-Host Variables
-++++++++++++++
+Assigning a variable to one machine: host variables
+===================================================
 
 As described above, it is easy to assign variables to hosts that will be used later in playbooks:
 
@@ -154,8 +155,8 @@ The YAML version:
 
 .. _group_variables:
 
-Group Variables
-+++++++++++++++
+Assigning a variable to many machines: group variables
+======================================================
 
 Variables can also be applied to an entire group at once:
 
@@ -187,11 +188,11 @@ Be aware that this is only a convenient way to apply variables to multiple hosts
 
 .. _subgroups:
 
-Groups of Groups, and Group Variables
-+++++++++++++++++++++++++++++++++++++
+Inheriting variable values: group variables for groups of groups
+----------------------------------------------------------------
 
-It is also possible to make groups of groups using the ``:children`` suffix in INI or the ``children:`` entry in YAML.
-You can apply variables using ``:vars`` or ``vars:``:
+You can make groups of groups using the ``:children`` suffix in INI or the ``children:`` entry in YAML.
+You can apply variables to these groups of groups using ``:vars`` or ``vars:``:
 
 
 .. code-block:: guess
@@ -256,7 +257,7 @@ Child groups have a couple of properties to note:
 .. _default_groups:
 
 Default groups
-++++++++++++++
+==============
 
 There are two default groups: ``all`` and ``ungrouped``. ``all`` contains every host.
 ``ungrouped`` contains all hosts that don't have another group aside from ``all``.
@@ -265,22 +266,18 @@ Though ``all`` and ``ungrouped`` are always present, they can be implicit and no
 
 .. _splitting_out_vars:
 
-Splitting Out Host and Group Specific Data
-++++++++++++++++++++++++++++++++++++++++++
+Organizing host and group variables
+===================================
 
-The preferred practice in Ansible is to not store variables in the main inventory file.
+Although you can store variables in the main inventory file, storing separate host and group variables files may help you track your variable values more easily.
 
-In addition to storing variables directly in the inventory file, host and group variables can be stored in individual files relative to the inventory file (not directory, it is always the file).
+Host and group variables can be stored in individual files relative to the inventory file (not directory, it is always the file).
 
 These variable files are in YAML format. Valid file extensions include '.yml', '.yaml', '.json', or no file extension.
 See :ref:`yaml_syntax` if you are new to YAML.
 
-Assuming the inventory file path is::
-
-    /etc/ansible/hosts
-
-If the host is named 'foosball', and in groups 'raleigh' and 'webservers', variables
-in YAML files at the following locations will be made available to the host::
+Let's say, for example, that you keep your inventory file at ``/etc/ansible/hosts``. You have a host named 'foosball' that's a member of two groups: 'raleigh' and 'webservers'. That host will use variables
+in YAML files at the following locations::
 
     /etc/ansible/group_vars/raleigh # can optionally end in '.yml', '.yaml', or '.json'
     /etc/ansible/group_vars/webservers
@@ -304,7 +301,7 @@ Ansible will read all the files in these directories in lexicographical order. A
 
 All hosts that are in the 'raleigh' group will have the variables defined in these files
 available to them. This can be very useful to keep your variables organized when a single
-file starts to be too big, or when you want to use :doc:`Ansible Vault<playbooks_vault>` on a part of a group's
+file starts to be too big, or when you want to use :ref:`Ansible Vault<playbooks_vault>` on a part of a group's
 variables.
 
 Tip: The ``group_vars/`` and ``host_vars/`` directories can exist in
@@ -320,8 +317,8 @@ is an excellent way to track changes to your inventory and host variables.
 
 .. _how_we_merge:
 
-How Variables Are Merged
-++++++++++++++++++++++++
+How variables are merged
+========================
 
 By default variables are merged/flattened to the specific host before a play is run. This keeps Ansible focused on the Host and Task, so groups don't really survive outside of inventory and host matching. By default, Ansible overwrites variables including the ones defined for a group and/or host (see :ref:`DEFAULT_HASH_BEHAVIOUR<DEFAULT_HASH_BEHAVIOUR>`). The order/precedence is (from lowest to highest):
 
@@ -348,8 +345,8 @@ In this example, if both groups have the same priority, the result would normall
 
 .. _behavioral_parameters:
 
-List of Behavioral Inventory Parameters
-+++++++++++++++++++++++++++++++++++++++
+Connecting to hosts: behavioral inventory parameters
+====================================================
 
 As described above, setting the following variables control how Ansible interacts with remote hosts.
 
@@ -392,7 +389,7 @@ ansible_ssh_executable (added in version 2.2)
     This setting overrides the default behavior to use the system :command:`ssh`. This can override the ``ssh_executable`` setting in :file:`ansible.cfg`.
 
 
-Privilege escalation (see :doc:`Ansible Privilege Escalation<become>` for further details):
+Privilege escalation (see :ref:`Ansible Privilege Escalation<become>` for further details):
 
 ansible_become
     Equivalent to ``ansible_sudo`` or ``ansible_su``, allows to force privilege escalation
@@ -449,7 +446,7 @@ Examples from an Ansible-INI host file::
   ruby_module_host  ansible_ruby_interpreter=/usr/bin/ruby.1.9.3
 
 Non-SSH connection types
-++++++++++++++++++++++++
+------------------------
 
 As stated in the previous section, Ansible executes playbooks over SSH but it is not limited to this connection type.
 With the host specific parameter ``ansible_connection=<connector>``, the connection type can be changed.

--- a/docs/docsite/rst/user_guide/playbooks_async.rst
+++ b/docs/docsite/rst/user_guide/playbooks_async.rst
@@ -30,6 +30,11 @@ poll value is 10 seconds if you do not specify a value for `poll`::
    'async' keyword, the task runs synchronously, which is Ansible's
    default.
 
+.. note::
+  As of Ansible 2.3, async does not support check mode and will fail the
+  task when run in check mode. See :doc:`playbooks_checkmode` on how to
+  skip a task in check mode.
+
 Alternatively, if you do not need to wait on the task to complete, you may
 run the task asynchronously by specifying a poll value of 0::
 
@@ -127,4 +132,3 @@ of tasks running concurrently, you can do it this way::
        Have a question?  Stop by the google group!
    `irc.freenode.net <http://irc.freenode.net>`_
        #ansible IRC chat channel
-

--- a/docs/docsite/rst/user_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/user_guide/playbooks_variables.rst
@@ -790,12 +790,10 @@ directory (ansible will attempt to create the directory if one does not exist).
 Registering variables
 =====================
 
-Another major use of variables is running a command and registering the result of that command as a variable. Results will vary from module to module. Use of ``-v`` when executing playbooks will show possible values for the results.
-
-The value of a task being executed in ansible can be saved in a variable and used later.  See some examples of this in the
+Another major use of variables is running a command and registering the result of that command as a variable. When you execute a task and save the return value in a variable for use in later tasks, you create a registered variable. There are more examples of this in the
 :ref:`playbooks_conditionals` chapter.
 
-While it's mentioned elsewhere in that document too, here's a quick syntax example::
+For example::
 
    - hosts: web_servers
 
@@ -808,10 +806,11 @@ While it's mentioned elsewhere in that document too, here's a quick syntax examp
         - shell: /usr/bin/bar
           when: foo_result.rc == 5
 
-Registered variables are valid on the host the remainder of the playbook run, which is the same as the lifetime of "facts"
-in Ansible.  Effectively registered variables are just like facts.
+Results will vary from module to module. Each module's documentation includes a ``RETURN`` section describing that module's return values. To see the values for a particular task, run your playbook with ``-v``.
 
-When using ``register`` with a loop, the data structure placed in the variable during the loop will contain a ``results`` attribute, that is a list of all responses from the module. For a more in-depth example of how this works, see the :ref:`playbooks_loops` section on using register with a loop.
+Registered variables are similar to facts, with a few key differences. Like facts, registered variables are host-level variables. However, registered variables are only stored in memory. (Ansible facts are backed by whatever cache plugin you have configured.) Registered variables are only valid on the host for the rest of the current playbook run. Finally, registered variables and facts have different :ref:`precedence levels <ansible_variable_precedence>`.
+
+When you register a variable in a task with a loop, the registered variable contains a value for each item in the loop. The data structure placed in the variable during the loop will contain a ``results`` attribute, that is a list of all responses from the module. For a more in-depth example of how this works, see the :ref:`playbooks_loops` section on using register with a loop.
 
 .. note:: If a task fails or is skipped, the variable still is registered with a failure or skipped status, the only way to avoid registering a variable is using tags.
 

--- a/examples/hosts.yaml
+++ b/examples/hosts.yaml
@@ -8,6 +8,8 @@
 #   - Hosts must be specified in a group's hosts:
 #     and they must be a key (: terminated)
 #   - groups can have children, hosts and vars keys
+#   - groups are unique and global - if you define a group in multiple locations, Ansible aggregates all the data to the global name.
+#   - If you define a group as a child of 2 different groups, it will be the child of both, any hosts and variables assigned will not be dependent on the parents, they will all be associated with the group.
 #   - Anything defined under a host is assumed to be a var
 #   - You can enter hostnames or IP addresses
 #   - A hostname/IP can be a member of multiple groups
@@ -32,7 +34,12 @@
 ##        192.168.1.110:
 
 # Ex 3: You can create hosts using ranges and add children groups and vars to a group
-# The child group can define anything you would normally add to a group
+# The child group can define anything you would normally add to a group.
+# webservers is added as a child group of testing. gamma.example.org is added
+# to the existing webservers group. All references to webservers will
+# get alpha.example.org, beta.example.org, gamma.example.org, 192.168.1.100
+# and 192.168.1.110. References to testing will get all of those hosts plus
+# any host matching www[001:006].example.com
 
 ##    testing:
 ##      hosts:
@@ -42,7 +49,7 @@
 ##      children:
 ##        webservers:
 ##            hosts:
-##                beta.example.org:
+##                gamma.example.org:
 
 # Ex 4: all vars
 # keeping within 'all' group you can define common 'all' vars here with lowest precedence

--- a/lib/ansible/config/module_defaults.yml
+++ b/lib/ansible/config/module_defaults.yml
@@ -140,6 +140,8 @@ groupings:
   - aws
   ec2_key:
   - aws
+  ec2_launch_template:
+  - aws
   ec2_lc:
   - aws
   ec2_lc_facts:

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -241,6 +241,10 @@ class TaskQueueManager:
         )
 
         play_context = PlayContext(new_play, self._options, self.passwords, self._connection_lockfile.fileno())
+        if (self._stdout_callback and
+                hasattr(self._stdout_callback, 'set_play_context')):
+            self._stdout_callback.set_play_context(play_context)
+
         for callback_plugin in self._callback_plugins:
             if hasattr(callback_plugin, 'set_play_context'):
                 callback_plugin.set_play_context(play_context)

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -267,7 +267,7 @@ class LinuxHardware(Hardware):
         if os.path.exists('/sys/devices/virtual/dmi/id/product_name'):
             # Use kernel DMI info, if available
 
-            # DMI SPEC -- http://www.dmtf.org/sites/default/files/standards/documents/DSP0134_2.7.0.pdf
+            # DMI SPEC -- https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.2.0.pdf
             FORM_FACTOR = ["Unknown", "Other", "Unknown", "Desktop",
                            "Low Profile Desktop", "Pizza Box", "Mini Tower", "Tower",
                            "Portable", "Laptop", "Notebook", "Hand Held", "Docking Station",
@@ -275,7 +275,9 @@ class LinuxHardware(Hardware):
                            "Main Server Chassis", "Expansion Chassis", "Sub Chassis",
                            "Bus Expansion Chassis", "Peripheral Chassis", "RAID Chassis",
                            "Rack Mount Chassis", "Sealed-case PC", "Multi-system",
-                           "CompactPCI", "AdvancedTCA", "Blade"]
+                           "CompactPCI", "AdvancedTCA", "Blade", "Blade Enclosure",
+                           "Tablet", "Convertible", "Detachable", "IoT Gateway",
+                           "Embedded PC", "Mini PC", "Stick PC"]
 
             DMI_DICT = {
                 'bios_date': '/sys/devices/virtual/dmi/id/bios_date',

--- a/lib/ansible/module_utils/network/netvisor/pn_nvos.py
+++ b/lib/ansible/module_utils/network/netvisor/pn_nvos.py
@@ -1,0 +1,72 @@
+# Copyright: (c) 2018, Pluribus Networks
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+import shlex
+
+
+def pn_cli(module, switch=None, username=None, password=None, switch_local=None):
+    """
+    Method to generate the cli portion to launch the Netvisor cli.
+    :param module: The Ansible module to fetch username and password.
+    :return: The cli string for further processing.
+    """
+
+    cli = '/usr/bin/cli --quiet -e --no-login-prompt '
+
+    if username and password:
+        cli += '--user "%s":"%s" ' % (username, password)
+    if switch:
+        cli += ' switch ' + switch
+    if switch_local:
+        cli += ' switch-local '
+
+    return cli
+
+
+def booleanArgs(arg, trueString, falseString):
+    if arg is True:
+        return " %s " % trueString
+    elif arg is False:
+        return " %s " % falseString
+    else:
+        return ""
+
+
+def run_cli(module, cli, state_map):
+    """
+    This method executes the cli command on the target node(s) and returns the
+    output. The module then exits based on the output.
+    :param cli: the complete cli string to be executed on the target node(s).
+    :param state_map: Provides state of the command.
+    :param module: The Ansible module to fetch command
+    """
+    state = module.params['state']
+    command = state_map[state]
+
+    cmd = shlex.split(cli)
+    result, out, err = module.run_command(cmd)
+
+    remove_cmd = '/usr/bin/cli --quiet -e --no-login-prompt'
+
+    results = dict(
+        command=' '.join(cmd).replace(remove_cmd, ''),
+        msg="%s operation completed" % command,
+        changed=True
+    )
+    # Response in JSON format
+    if result != 0:
+        module.exit_json(
+            command=' '.join(cmd).replace(remove_cmd, ''),
+            stderr=err.strip(),
+            msg="%s operation failed" % command,
+            changed=False
+        )
+
+    if out:
+        results['stdout'] = out.strip()
+    module.exit_json(**results)

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -583,9 +583,10 @@ def download_s3file(module, s3, bucket, obj, dest, retries, version=None):
     except botocore.exceptions.BotoCoreError as e:
         module.fail_json_aws(e, msg="Could not find the key %s." % obj)
 
+    optional_kwargs = {'ExtraArgs': {'VersionId': version}} if version else {}
     for x in range(0, retries + 1):
         try:
-            s3.download_file(bucket, obj, dest)
+            s3.download_file(bucket, obj, dest, **optional_kwargs)
             module.exit_json(msg="GET operation complete", changed=True)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             # actually fail on last pass through the loop.

--- a/lib/ansible/modules/cloud/amazon/ec2_launch_template.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_launch_template.py
@@ -1,0 +1,649 @@
+#!/usr/bin/python
+# Copyright (c) 2018 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: ec2_launch_template
+version_added: "2.8"
+short_description: Manage EC2 launch templates
+description:
+  - Create, modify, and delete EC2 Launch Templates, which can be used to
+    create individual instances or with Autoscaling Groups.
+  - The I(ec2_instance) and I(ec2_asg) modules can, instead of specifying all
+    parameters on those tasks, be passed a Launch Template which contains
+    settings like instance size, disk type, subnet, and more.
+requirements:
+  - botocore
+  - boto3 >= 1.6.0
+extends_documentation_fragment:
+  - aws
+  - ec2
+author:
+  - Ryan Scott Brown (@ryansb)
+options:
+  template_id:
+    description:
+    - The ID for the launch template, can be used for all cases except creating a new Launch Template.
+    aliases: [id]
+  template_name:
+    description:
+    - The template name. This must be unique in the region-account combination you are using.
+    aliases: [name]
+  default_version:
+    description:
+    - Which version should be the default when users spin up new instances based on this template? By default, the latest version will be made the default.
+    default: latest
+  state:
+    description:
+    - Whether the launch template should exist or not. To delete only a
+      specific version of a launch template, combine I(state=absent) with
+      the I(version) option. By default, I(state=absent) will remove all
+      versions of the template.
+    choices: [present, absent]
+    default: present
+  block_device_mappings:
+    description:
+    - The block device mapping. Supplying both a snapshot ID and an encryption
+      value as arguments for block-device mapping results in an error. This is
+      because only blank volumes can be encrypted on start, and these are not
+      created from a snapshot. If a snapshot is the basis for the volume, it
+      contains data by definition and its encryption status cannot be changed
+      using this action.
+    suboptions:
+      device_name:
+        description: The device name (for example, /dev/sdh or xvdh).
+      no_device:
+        description: Suppresses the specified device included in the block device mapping of the AMI.
+      virtual_name:
+        description: >
+          The virtual device name (ephemeralN). Instance store volumes are
+          numbered starting from 0. An instance type with 2 available instance
+          store volumes can specify mappings for ephemeral0 and ephemeral1. The
+          number of available instance store volumes depends on the instance
+          type. After you connect to the instance, you must mount the volume.
+      ebs:
+        description: Parameters used to automatically set up EBS volumes when the instance is launched.
+        suboptions:
+          delete_on_termintation:
+            description: Indicates whether the EBS volume is deleted on instance termination.
+            type: bool
+          encrypted:
+            description: >
+              Indicates whether the EBS volume is encrypted. Encrypted volumes
+              can only be attached to instances that support Amazon EBS
+              encryption. If you are creating a volume from a snapshot, you
+              can't specify an encryption value.
+          iops:
+            description:
+            - The number of I/O operations per second (IOPS) that the volume
+              supports. For io1, this represents the number of IOPS that are
+              provisioned for the volume. For gp2, this represents the baseline
+              performance of the volume and the rate at which the volume
+              accumulates I/O credits for bursting. For more information about
+              General Purpose SSD baseline performance, I/O credits, and
+              bursting, see Amazon EBS Volume Types in the Amazon Elastic
+              Compute Cloud User Guide.
+            - >
+              Condition: This parameter is required for requests to create io1
+              volumes; it is not used in requests to create gp2, st1, sc1, or
+              standard volumes.
+          kms_key_id:
+            description: The ARN of the AWS Key Management Service (AWS KMS) CMK used for encryption.
+          snapshot_id:
+            description: The ID of the snapshot to create the volume from
+          volume_size:
+            description:
+            - The size of the volume, in GiB.
+            - "Default: If you're creating the volume from a snapshot and don't specify a volume size, the default is the snapshot size."
+          volume_type:
+            description: The volume type
+  cpu_options:
+    description:
+    - Choose CPU settings for the EC2 instances that will be created with this template.
+    - For more information, see U(http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-optimize-cpu.html)
+    suboptions:
+      core_count:
+        description: The number of CPU cores for the instance.
+      threads_per_core:
+        description: >
+          The number of threads per CPU core. To disable Intel Hyper-Threading
+          Technology for the instance, specify a value of 1. Otherwise, specify
+          the default value of 2.
+  credit_specification:
+    description: The credit option for CPU usage of the instance. Valid for T2 or T3 instances only.
+    suboptions:
+      cpu_credits:
+        description: >
+          The credit option for CPU usage of a T2 or T3 instance. Valid values
+          are I(standard) and I(unlimited).
+        choices: [standard, unlimited]
+  disable_api_termination:
+    description: >
+      This helps protect instances from accidental termination. If set to true,
+      you can't terminate the instance using the Amazon EC2 console, CLI, or
+      API. To change this attribute to false after launch, use
+      I(ModifyInstanceAttribute).
+    type: bool
+  ebs_optimized:
+    description: >
+      Indicates whether the instance is optimized for Amazon EBS I/O. This
+      optimization provides dedicated throughput to Amazon EBS and an optimized
+      configuration stack to provide optimal Amazon EBS I/O performance. This
+      optimization isn't available with all instance types. Additional usage
+      charges apply when using an EBS-optimized instance.
+    type: bool
+  elastic_gpu_specifications:
+    description: Settings for Elastic GPU attachments. See U(https://aws.amazon.com/ec2/elastic-gpus/) for details.
+    suboptions:
+      type:
+        description: The type of Elastic GPU to attach
+  iam_instance_profile:
+    description: >
+      The name or ARN of an IAM instance profile. Requires permissions to
+      describe existing instance roles to confirm ARN is properly formed.
+  image_id:
+    description: >
+      The AMI ID to use for new instances launched with this template. This
+      value is region-dependent since AMIs are not global resources.
+  instance_initiated_shutdown_behavior:
+    description: >
+      Indicates whether an instance stops or terminates when you initiate
+      shutdown from the instance using the operating system shutdown command.
+    choices: [stop, terminate]
+  instance_market_options:
+    description: Options for alternative instance markets, currently only the spot market is supported.
+    suboptions:
+      market_type:
+        description: The market type. This should always be 'spot'.
+      spot_options:
+        description: Spot-market specific settings
+        suboptions:
+          block_duration_minutes:
+            description: >
+              The required duration for the Spot Instances (also known as Spot
+              blocks), in minutes. This value must be a multiple of 60 (60,
+              120, 180, 240, 300, or 360).
+          instance_interruption_behavior:
+            description: The behavior when a Spot Instance is interrupted. The default is I(terminate)
+            choices: [hibernate, stop, terminate]
+          max_price:
+            description: The highest hourly price you're willing to pay for this Spot Instance.
+          spot_instance_type:
+            description: The request type to send.
+            choices: [one-time, persistent]
+    type: dict
+  instance_type:
+    description: >
+      The instance type, such as I(c5.2xlarge). For a full list of instance types, see
+      http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html
+  kernel_id:
+    description: >
+      The ID of the kernel. We recommend that you use PV-GRUB instead of
+      kernels and RAM disks. For more information, see
+      U(http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/UserProvidedkernels.html)
+  key_name:
+    description:
+    - The name of the key pair. You can create a key pair using
+      I(CreateKeyPair) or I(ImportKeyPair).
+    - If you do not specify a key pair, you can't connect to the instance
+      unless you choose an AMI that is configured to allow users another way to
+      log in.
+  monitoring:
+    description: Settings for instance monitoring
+    suboptions:
+      enabled:
+        type: bool
+        description: Whether to turn on detailed monitoring for new instances. This will incur extra charges.
+  network_interfaces:
+    description: One or more network interfaces.
+    suboptions:
+      associate_public_ip_address:
+        description: Associates a public IPv4 address with eth0 for a new network interface.
+        type: bool
+      delete_on_termination:
+        description: Indicates whether the network interface is deleted when the instance is terminated.
+        type: bool
+      description:
+        description: A description for the network interface.
+      device_index:
+        description: The device index for the network interface attachment.
+      groups:
+        description: List of security group IDs to include on this instance
+      ipv6_address_count:
+        description: >
+          The number of IPv6 addresses to assign to a network interface. Amazon
+          EC2 automatically selects the IPv6 addresses from the subnet range.
+          You can't use this option if specifying the I(ipv6_addresses) option.
+      ipv6_addresses:
+        description: >
+          A list of one or more specific IPv6 addresses from the IPv6 CIDR
+          block range of your subnet. You can't use this option if you're
+          specifying the I(ipv6_address_count) option.
+      network_interface_id:
+        description: The eni ID of a network interface to attach.
+      private_ip_address:
+        description: The primary private IPv4 address of the network interface.
+      private_ip_addresses:
+        description: One or more private IPv4 addresses.
+        suboptions:
+          primary:
+            description: >
+              Indicates whether the private IPv4 address is the primary private
+              IPv4 address. Only one IPv4 address can be designated as primary.
+          private_ip_address:
+            description: The primary private IPv4 address of the network interface.
+      subnet_id:
+        description: The ID of the subnet for the network interface.
+      secondary_private_ip_address_count:
+        description: The number of secondary private IPv4 addresses to assign to a network interface.
+  placement:
+    description: The placement group settings for the instance.
+    suboptions:
+      affinity:
+        description: The affinity setting for an instance on a Dedicated Host.
+      availability_zone:
+        description: The Availability Zone for the instance.
+      group_name:
+        description: The name of the placement group for the instance.
+      host_id:
+        description: The ID of the Dedicated Host for the instance.
+      tenancy:
+        description: >
+          The tenancy of the instance (if the instance is running in a VPC). An
+          instance with a tenancy of dedicated runs on single-tenant hardware.
+  ram_disk_id:
+    description: >
+      The ID of the RAM disk to launch the instance with. We recommend that you
+      use PV-GRUB instead of kernels and RAM disks. For more information, see
+      U(http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/UserProvidedkernels.html)
+  security_group_ids:
+    description: A list of security group IDs (VPC or EC2-Classic) that the new instances will be added to.
+    type: list
+  security_groups:
+    description: A list of security group names (VPC or EC2-Classic) that the new instances will be added to.
+    type: list
+  tags:
+    type: dict
+    description:
+    - A set of key-value pairs to be applied to resources when this Launch Template is used.
+    - "Tag key constraints: Tag keys are case-sensitive and accept a maximum of 127 Unicode characters. May not begin with I(aws:)"
+    - "Tag value constraints: Tag values are case-sensitive and accept a maximum of 255 Unicode characters."
+  user_data:
+    description: >
+      The Base64-encoded user data to make available to the instance. For more information, see the Linux
+      U(http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html) and Windows
+      U(http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2-instance-metadata.html#instancedata-add-user-data)
+      documentation on user-data.
+'''
+
+EXAMPLES = '''
+- name: Make instance with an instance_role
+  ec2_launch_template:
+    name: "test-with-instance-role"
+    image_id: "ami-foobarbaz"
+    key_name: my_ssh_key
+    instance_type: t2.micro
+    iam_instance_profile: myTestProfile
+    disable_api_termination: true
+
+- name: Make one with a different instance type, but leave the older version as default
+  ec2_launch_template:
+    name: "test-with-instance-role"
+    image_id: "ami-foobarbaz"
+    default_version: 1
+    key_name: my_ssh_key
+    instance_type: c5.4xlarge
+    iam_instance_profile: myTestProfile
+    disable_api_termination: true
+'''
+
+RETURN = '''
+latest_version:
+  description: Latest available version of the launch template
+  returned: when state=present
+  type: int
+default_version:
+  description: The version that will be used if only the template name is specified. Often this is the same as the latest version, but not always.
+  returned: when state=present
+  type: int
+'''
+import re
+from uuid import uuid4
+
+from ansible.module_utils._text import to_text
+from ansible.module_utils.aws.core import AnsibleAWSModule, is_boto3_error_code, get_boto3_client_method_parameters
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict, snake_dict_to_camel_dict
+from ansible.module_utils.ec2 import ansible_dict_to_boto3_tag_list, AWSRetry, boto3_tag_list_to_ansible_dict, ansible_dict_to_boto3_tag_list
+
+try:
+    from botocore.exceptions import ClientError, BotoCoreError, WaiterError
+except ImportError:
+    pass  # caught by AnsibleAWSModule
+
+
+def determine_iam_role(module, name_or_arn):
+    if re.match(r'^arn:aws:iam::\d+:instance-profile/[\w+=/,.@-]+$', name_or_arn):
+        return name_or_arn
+    iam = module.client('iam', retry_decorator=AWSRetry.jittered_backoff())
+    try:
+        role = iam.get_instance_profile(InstanceProfileName=name_or_arn, aws_retry=True)
+        return {'arn': role['InstanceProfile']['Arn']}
+    except is_boto3_error_code('NoSuchEntity') as e:
+        module.fail_json_aws(e, msg="Could not find instance_role {0}".format(name_or_arn))
+    except (BotoCoreError, ClientError) as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg="An error occurred while searching for instance_role {0}. Please try supplying the full ARN.".format(name_or_arn))
+
+
+def existing_templates(module):
+    ec2 = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())
+    matches = None
+    try:
+        if module.params.get('template_id'):
+            matches = ec2.describe_launch_templates(LaunchTemplateIds=[module.params.get('template_id')])
+        elif module.params.get('template_name'):
+            matches = ec2.describe_launch_templates(LaunchTemplateNames=[module.params.get('template_name')])
+    except is_boto3_error_code('InvalidLaunchTemplateName.NotFoundException') as e:
+        # no named template was found, return nothing/empty versions
+        return None, []
+    except is_boto3_error_code('InvalidLaunchTemplateId.Malformed') as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg='Launch template with ID {0} is not a valid ID. It should start with `lt-....`'.format(
+            module.params.get('launch_template_id')))
+    except is_boto3_error_code('InvalidLaunchTemplateId.NotFoundException') as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(
+            e, msg='Launch template with ID {0} could not be found, please supply a name '
+            'instead so that a new template can be created'.format(module.params.get('launch_template_id')))
+    except (ClientError, BotoCoreError, WaiterError) as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg='Could not check existing launch templates. This may be an IAM permission problem.')
+    else:
+        template = matches['LaunchTemplates'][0]
+        template_id, template_version, template_default = template['LaunchTemplateId'], template['LatestVersionNumber'], template['DefaultVersionNumber']
+        try:
+            return template, ec2.describe_launch_template_versions(LaunchTemplateId=template_id)['LaunchTemplateVersions']
+        except (ClientError, BotoCoreError, WaiterError) as e:
+            module.fail_json_aws(e, msg='Could not find launch template versions for {0} (ID: {1}).'.format(template['LaunchTemplateName'], template_id))
+
+
+def params_to_launch_data(module, template_params):
+    if template_params.get('tags'):
+        template_params['tag_specifications'] = [
+            {
+                'resource_type': r_type,
+                'tags': [
+                    {'Key': k, 'Value': v} for k, v
+                    in template_params['tags'].items()
+                ]
+            }
+            for r_type in ('instance', 'network-interface', 'volume')
+        ]
+        del template_params['tags']
+    if module.params.get('iam_instance_profile'):
+        template_params['iam_instance_profile'] = determine_iam_role(module, module.params['iam_instance_profile'])
+    params = snake_dict_to_camel_dict(
+        dict((k, v) for k, v in template_params.items() if v is not None),
+        capitalize_first=True,
+    )
+    return params
+
+
+def delete_template(module):
+    ec2 = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())
+    template, template_versions = existing_templates(module)
+    deleted_versions = []
+    if template or template_versions:
+        non_default_versions = [to_text(t['VersionNumber']) for t in template_versions if not t['DefaultVersion']]
+        if non_default_versions:
+            try:
+                v_resp = ec2.delete_launch_template_versions(
+                    LaunchTemplateId=template['LaunchTemplateId'],
+                    Versions=non_default_versions,
+                )
+                if v_resp['UnsuccessfullyDeletedLaunchTemplateVersions']:
+                    module.warn('Failed to delete template versions {0} on launch template {1}'.format(
+                        v_resp['UnsuccessfullyDeletedLaunchTemplateVersions'],
+                        template['LaunchTemplateId'],
+                    ))
+                deleted_versions = [camel_dict_to_snake_dict(v) for v in v_resp['SuccessfullyDeletedLaunchTemplateVersions']]
+            except (ClientError, BotoCoreError) as e:
+                module.fail_json_aws(e, msg="Could not delete existing versions of the launch template {0}".format(template['LaunchTemplateId']))
+        try:
+            resp = ec2.delete_launch_template(
+                LaunchTemplateId=template['LaunchTemplateId'],
+            )
+        except (ClientError, BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Could not delete launch template {0}".format(template['LaunchTemplateId']))
+        return {
+            'deleted_versions': deleted_versions,
+            'deleted_template': camel_dict_to_snake_dict(resp['LaunchTemplate']),
+            'changed': True,
+        }
+    else:
+        return {'changed': False}
+
+
+def create_or_update(module, template_options):
+    ec2 = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())
+    template, template_versions = existing_templates(module)
+    out = {}
+    lt_data = params_to_launch_data(module, dict((k, v) for k, v in module.params.items() if k in template_options))
+    if not (template or template_versions):
+        # create a full new one
+        try:
+            resp = ec2.create_launch_template(
+                LaunchTemplateName=module.params['template_name'],
+                LaunchTemplateData=lt_data,
+                ClientToken=uuid4().hex,
+                aws_retry=True,
+            )
+        except (ClientError, BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Couldn't create launch template")
+        template, template_versions = existing_templates(module)
+        out['changed'] = True
+    elif template and template_versions:
+        most_recent = sorted(template_versions, key=lambda x: x['VersionNumber'])[-1]
+        if lt_data == most_recent['LaunchTemplateData']:
+            out['changed'] = False
+            return out
+        try:
+            resp = ec2.create_launch_template_version(
+                LaunchTemplateId=template['LaunchTemplateId'],
+                LaunchTemplateData=lt_data,
+                ClientToken=uuid4().hex,
+                aws_retry=True,
+            )
+            if module.params.get('default_version') in (None, ''):
+                # no need to do anything, leave the existing version as default
+                pass
+            elif module.params.get('default_version') == 'latest':
+                set_default = ec2.modify_launch_template(
+                    LaunchTemplateId=template['LaunchTemplateId'],
+                    DefaultVersion=to_text(resp['LaunchTemplateVersion']['VersionNumber']),
+                    ClientToken=uuid4().hex,
+                    aws_retry=True,
+                )
+            else:
+                try:
+                    int(module.params.get('default_version'))
+                except ValueError:
+                    module.fail_json(msg='default_version param was not a valid integer, got "{0}"'.format(module.params.get('default_version')))
+                set_default = ec2.modify_launch_template(
+                    LaunchTemplateId=template['LaunchTemplateId'],
+                    DefaultVersion=to_text(int(module.params.get('default_version'))),
+                    ClientToken=uuid4().hex,
+                    aws_retry=True,
+                )
+        except (ClientError, BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Couldn't create subsequent launch template version")
+        template, template_versions = existing_templates(module)
+        out['changed'] = True
+    return out
+
+
+def format_module_output(module):
+    output = {}
+    template, template_versions = existing_templates(module)
+    template = camel_dict_to_snake_dict(template)
+    template_versions = [camel_dict_to_snake_dict(v) for v in template_versions]
+    for v in template_versions:
+        for ts in (v['launch_template_data'].get('tag_specifications') or []):
+            ts['tags'] = boto3_tag_list_to_ansible_dict(ts.pop('tags'))
+    output.update(dict(template=template, versions=template_versions))
+    output['default_template'] = [
+        v for v in template_versions
+        if v.get('default_version')
+    ][0]
+    output['latest_template'] = [
+        v for v in template_versions
+        if (
+            v.get('version_number') and
+            int(v['version_number']) == int(template['latest_version_number'])
+        )
+    ][0]
+    return output
+
+
+def main():
+    template_options = dict(
+        block_device_mappings=dict(
+            type='list',
+            options=dict(
+                device_name=dict(),
+                ebs=dict(
+                    type='dict',
+                    options=dict(
+                        delete_on_termination=dict(type='bool'),
+                        encrypted=dict(type='bool'),
+                        iops=dict(type='int'),
+                        kms_key_id=dict(),
+                        snapshot_id=dict(),
+                        volume_size=dict(type='int'),
+                        volume_type=dict(),
+                    ),
+                ),
+                no_device=dict(),
+                virtual_name=dict(),
+            ),
+        ),
+        cpu_options=dict(
+            type='dict',
+            options=dict(
+                core_count=dict(type='int'),
+                threads_per_core=dict(type='int'),
+            ),
+        ),
+        credit_specification=dict(
+            dict(type='dict'),
+            options=dict(
+                cpu_credits=dict(),
+            ),
+        ),
+        disable_api_termination=dict(type='bool'),
+        ebs_optimized=dict(type='bool'),
+        elastic_gpu_specifications=dict(
+            options=dict(type=dict()),
+            type='list',
+        ),
+        iam_instance_profile=dict(),
+        image_id=dict(),
+        instance_initiated_shutdown_behavior=dict(choices=['stop', 'terminate']),
+        instance_market_options=dict(
+            type='dict',
+            options=dict(
+                market_type=dict(),
+                spot_options=dict(
+                    type='dict',
+                    options=dict(
+                        block_duration_minutes=dict(type='int'),
+                        instance_interruption_behavior=dict(choices=['hibernate', 'stop', 'terminate']),
+                        max_price=dict(),
+                        spot_instance_type=dict(choices=['one-time', 'persistent']),
+                    ),
+                ),
+            ),
+        ),
+        instance_type=dict(),
+        kernel_id=dict(),
+        key_name=dict(),
+        monitoring=dict(
+            type='dict',
+            options=dict(
+                enabled=dict(type='bool')
+            ),
+        ),
+        network_interfaces=dict(
+            type='list',
+            options=dict(
+                associate_public_ip_address=dict(type='bool'),
+                delete_on_termination=dict(type='bool'),
+                description=dict(),
+                device_index=dict(type='int'),
+                groups=dict(type='list'),
+                ipv6_address_count=dict(type='int'),
+                ipv6_addresses=dict(type='list'),
+                network_interface_id=dict(),
+                private_ip_address=dict(),
+                subnet_id=dict(),
+            ),
+        ),
+        placement=dict(
+            options=dict(
+                affinity=dict(),
+                availability_zone=dict(),
+                group_name=dict(),
+                host_id=dict(),
+                tenancy=dict(),
+            ),
+            type='dict',
+        ),
+        ram_disk_id=dict(),
+        security_group_ids=dict(type='list'),
+        security_groups=dict(type='list'),
+        tags=dict(type='dict'),
+        user_data=dict(),
+    )
+
+    arg_spec = dict(
+        state=dict(choices=['present', 'absent'], default='present'),
+        template_name=dict(aliases=['name']),
+        template_id=dict(aliases=['id']),
+        default_version=dict(default='latest'),
+    )
+
+    arg_spec.update(template_options)
+
+    module = AnsibleAWSModule(
+        argument_spec=arg_spec,
+        required_one_of=[
+            ('template_name', 'template_id')
+        ],
+        supports_check_mode=True
+    )
+
+    if not module.boto3_at_least('1.6.0'):
+        module.fail_json(msg="ec2_launch_template requires boto3 >= 1.6.0")
+
+    for interface in (module.params.get('network_interfaces') or []):
+        if interface.get('ipv6_addresses'):
+            interface['ipv6_addresses'] = [{'ipv6_address': x} for x in interface['ipv6_addresses']]
+
+    if module.params.get('state') == 'present':
+        out = create_or_update(module, template_options)
+        out.update(format_module_output(module))
+    elif module.params.get('state') == 'absent':
+        out = delete_template(module)
+    else:
+        module.fail_json(msg='Unsupported value "{0}" for `state` parameter'.format(module.params.get('state')))
+
+    module.exit_json(**out)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/elb_application_lb_facts.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb_facts.py
@@ -50,6 +50,13 @@ EXAMPLES = '''
     names:
       - elb1
       - elb2
+
+# Gather facts about specific ALB
+- elb_application_lb_facts:
+    names: "alb-name"
+    region: "aws-region"
+  register: alb_facts
+- debug: var=alb_facts
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/azure/azure_rm_keyvaultkey.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_keyvaultkey.py
@@ -149,6 +149,7 @@ class AzureRMKeyVaultKey(AzureRMModuleBase):
                 client_id=self.credentials['client_id'],
                 secret=self.credentials['secret'],
                 tenant=tenant,
+                cloud_environment=self._cloud_environment,
                 resource="https://vault.azure.net")
 
             token = authcredential.token

--- a/lib/ansible/modules/cloud/azure/azure_rm_keyvaultsecret.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_keyvaultsecret.py
@@ -141,6 +141,7 @@ class AzureRMKeyVaultSecret(AzureRMModuleBase):
                 client_id=self.credentials['client_id'],
                 secret=self.credentials['secret'],
                 tenant=tenant,
+                cloud_environment=self._cloud_environment,
                 resource="https://vault.azure.net")
 
             token = authcredential.token

--- a/lib/ansible/modules/cloud/lxd/lxd_container.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_container.py
@@ -551,9 +551,6 @@ def main():
             config=dict(
                 type='dict',
             ),
-            description=dict(
-                type='str',
-            ),
             devices=dict(
                 type='dict',
             ),

--- a/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
@@ -1,218 +1,711 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-
+#
 # Copyright: (c) 2015, Joseph Callen <jcallen () csc.com>
+# Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
+# Copyright: (c) 2018, Christian Kotte <christian.kotte@gmx.de>
+# Copyright: (c) 2018, Ansible Project
+#
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
 
 DOCUMENTATION = '''
 ---
 module: vmware_dvswitch
-short_description: Create or remove a distributed vSwitch
+short_description: Create or remove a Distributed Switch
 description:
-    - Create or remove a distributed vSwitch
+    - This module can be used to create, remove a Distributed Switch.
 version_added: 2.0
 author:
 - Joseph Callen (@jcpowermac)
+- Abhijeet Kasurde (@Akasurde)
+- Christian Kotte (@ckotte)
 notes:
-    - Tested on vSphere 6.5
+    - Tested on vSphere 6.5 and 6.7
 requirements:
     - "python >= 2.6"
     - PyVmomi
 options:
     datacenter_name:
         description:
-            - The name of the datacenter that will contain the dvSwitch
+            - The name of the datacenter that will contain the Distributed Switch.
         required: True
+        aliases: ['datacenter']
     switch_name:
         description:
-            - The name of the switch to create or remove
+        - The name of the distribute vSwitch to create or remove.
         required: True
+        aliases: ['switch', 'dvswitch']
     switch_version:
         description:
-            - The version of the switch to create. Can be 6.5.0, 6.0.0, 5.5.0, 5.1.0, 5.0.0 with a vcenter running vSphere 6.5
-            - Needed if you have a vcenter version > ESXi version to join DVS. If not specified version=version of vcenter
-        required: False
+            - The version of the Distributed Switch to create.
+            - Can be 6.0.0, 5.5.0, 5.1.0, 5.0.0 with a vCenter running vSphere 6.0 and 6.5.
+            - Can be 6.6.0, 6.5.0, 6.0.0 with a vCenter running vSphere 6.7.
+            - The version must macht the version of the ESXi hosts you want to connect.
+            - The version of the vCenter server is used if not specified.
+            - Required only if C(state) is set to C(present).
         version_added: 2.5
+        choices: ['5.0.0', '5.1.0', '5.5.0', '6.0.0', '6.5.0', '6.6.0']
+        aliases: ['version']
     mtu:
         description:
-            - The switch maximum transmission unit
-        required: True
+            - The switch maximum transmission unit.
+            - Required parameter for C(state) both C(present) and C(absent), before Ansible 2.6 version.
+            - Required only if C(state) is set to C(present), for Ansible 2.6 and onwards.
+            - Accepts value between 1280 to 9000 (both inclusive).
+        type: int
+        default: 1500
+    multicast_filtering_mode:
+        description:
+            - The multicast filtering mode.
+            - 'C(basic) mode: multicast traffic for virtual machines is forwarded according to the destination MAC address of the multicast group.'
+            - 'C(snooping) mode: the Distributed Switch provides IGMP and MLD snooping according to RFC 4541.'
+        type: str
+        choices: ['basic', 'snooping']
+        default: 'basic'
+        version_added: 2.8
     uplink_quantity:
         description:
-            - Quantity of uplink per ESXi host added to the switch
-        required: True
+            - Quantity of uplink per ESXi host added to the Distributed Switch.
+            - The uplink quantity can be increased or decreased, but a decrease will only be successfull if the uplink isn't used by a portgroup.
+            - Required parameter for C(state) both C(present) and C(absent), before Ansible 2.6 version.
+            - Required only if C(state) is set to C(present), for Ansible 2.6 and onwards.
+    uplink_prefix:
+        description:
+            - The prefix used for the naming of the uplinks.
+            - Only valid if the Distributed Switch will be created. Not used if the Distributed Switch is already present.
+            - Uplinks are created as Uplink 1, Uplink 2, etc. pp. by default.
+        default: 'Uplink '
+        version_added: 2.8
     discovery_proto:
         description:
-            - Link discovery protocol between Cisco and Link Layer discovery
-        choices:
-            - 'cdp'
-            - 'lldp'
-        required: True
+            - Link discovery protocol between Cisco and Link Layer discovery.
+            - Required parameter for C(state) both C(present) and C(absent), before Ansible 2.6 version.
+            - Required only if C(state) is set to C(present), for Ansible 2.6 and onwards.
+            - 'C(cdp): Use Cisco Discovery Protocol (CDP).'
+            - 'C(lldp): Use Link Layer Discovery Protocol (LLDP).'
+            - 'C(disabled): Do not use a discovery protocol.'
+        choices: ['cdp', 'lldp', 'disabled']
+        default: 'cdp'
+        aliases: ['discovery_protocol']
     discovery_operation:
         description:
-            - Select the discovery operation
-        choices:
-            - 'both'
-            - 'none'
-            - 'advertise'
-            - 'listen'
+            - Select the discovery operation.
+            - Required parameter for C(state) both C(present) and C(absent), before Ansible 2.6 version.
+            - Required only if C(state) is set to C(present), for Ansible 2.6 and onwards.
+        choices: ['both', 'advertise', 'listen']
+        default: 'listen'
+    contact:
+        description:
+            - Dictionary which configures administrtor contact name and description for the Distributed Switch.
+            - 'Valid attributes are:'
+            - '- C(name) (str): Administrator name.'
+            - '- C(description) (str): Description or other details.'
+        type: dict
+        version_added: 2.8
+    description:
+        description:
+            - Description of the Distributed Switch.
+        type: str
+        version_added: 2.8
+    health_check:
+        description:
+            - Dictionary which configures Health Check for the Distributed Switch.
+            - 'Valid attributes are:'
+            - '- C(vlan_mtu) (bool): VLAN and MTU health check. (default: False)'
+            - '- C(teaming_failover) (bool): Teaming and failover health check. (default: False)'
+            - '- C(vlan_mtu_interval) (int): VLAN and MTU health check interval (minutes). (default: 0)'
+            - '- The default for C(vlan_mtu_interval) is 1 in the vSphere Client if the VLAN and MTU health check is enabled.'
+            - '- C(teaming_failover_interval) (int): Teaming and failover health check interval (minutes). (default: 0)'
+            - '- The default for C(teaming_failover_interval) is 1 in the vSphere Client if the Teaming and failover health check is enabled.'
+        type: dict
+        default: {
+            vlan_mtu: False,
+            teaming_failover: False,
+            vlan_mtu_interval: 0,
+            teaming_failover_interval: 0,
+        }
+        version_added: 2.8
     state:
         description:
-            - Create or remove dvSwitch
+            - If set to C(present) and the Distributed Switch doesn't exists then the Distributed Switch will be created.
+            - If set to C(absent) and the Distributed Switch exists then the Distributed Switch will be deleted.
         default: 'present'
-        choices:
-            - 'present'
-            - 'absent'
-        required: False
+        choices: ['present', 'absent']
 extends_documentation_fragment: vmware.documentation
 '''
+
 EXAMPLES = '''
-- name: Create dvswitch
+- name: Create dvSwitch
   vmware_dvswitch:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
-    datacenter_name: datacenter
-    switch_name: dvSwitch
-    switch_version: 6.0.0
+    datacenter: '{{ datacenter }}'
+    switch: dvSwitch
+    version: 6.0.0
     mtu: 9000
     uplink_quantity: 2
-    discovery_proto: lldp
+    discovery_protocol: lldp
     discovery_operation: both
     state: present
   delegate_to: localhost
+
+- name: Create dvSwitch with all options
+  vmware_dvswitch:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter: '{{ datacenter }}'
+    switch: dvSwitch
+    version: 6.5.0
+    mtu: 9000
+    uplink_quantity: 2
+    uplink_prefix: 'Uplink_'
+    discovery_protocol: cdp
+    discovery_operation: both
+    multicast_filtering_mode: snooping
+    health_check:
+      vlan_mtu: true
+      vlan_mtu_interval: 1
+      teaming_failover: true
+      teaming_failover_interval: 1
+    state: present
+  delegate_to: localhost
+
+- name: Delete dvSwitch
+  vmware_dvswitch:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter: '{{ datacenter }}'
+    switch: dvSwitch
+    state: absent
+  delegate_to: localhost
 '''
+
+RETURN = """
+result:
+    description: information about performed operation
+    returned: always
+    type: string
+    sample: {
+        "changed": false,
+        "contact": null,
+        "contact_details": null,
+        "description": null,
+        "discovery_operation": "both",
+        "discovery_protocol": "cdp",
+        "dvswitch": "test",
+        "health_check_teaming": false,
+        "health_check_teaming_interval": 0,
+        "health_check_vlan": false,
+        "health_check_vlan_interval": 0,
+        "mtu": 9000,
+        "multicast_filtering_mode": "basic",
+        "result": "DVS already configured properly",
+        "uplink_quantity": 2,
+        "uplinks": [
+            "Uplink_1",
+            "Uplink_2"
+        ],
+        "version": "6.6.0"
+    }
+"""
 
 try:
     from pyVmomi import vim, vmodl
-    HAS_PYVMOMI = True
 except ImportError:
-    HAS_PYVMOMI = False
+    pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.vmware import (HAS_PYVMOMI,
-                                         connect_to_api,
-                                         find_datacenter_by_name,
-                                         find_dvs_by_name,
-                                         vmware_argument_spec,
-                                         wait_for_task
-                                         )
+from ansible.module_utils._text import to_native
+from ansible.module_utils.vmware import (
+    PyVmomi, find_datacenter_by_name, TaskError, find_dvs_by_name, vmware_argument_spec, wait_for_task
+)
 
 
-class VMwareDVSwitch(object):
-
+class VMwareDvSwitch(PyVmomi):
+    """Class to manage a Distributed Virtual Switch"""
     def __init__(self, module):
-        self.module = module
+        super(VMwareDvSwitch, self).__init__(module)
         self.dvs = None
+        self.datacenter = None
         self.switch_name = self.module.params['switch_name']
         self.switch_version = self.module.params['switch_version']
+        if self.content.about.version == '6.7.0':
+            self.vcenter_switch_version = '6.6.0'
+        else:
+            self.vcenter_switch_version = self.content.about.version
         self.datacenter_name = self.module.params['datacenter_name']
         self.mtu = self.module.params['mtu']
+        # MTU sanity check
+        if not 1280 <= self.mtu <= 9000:
+            self.module.fail_json(
+                msg="MTU value should be between 1280 and 9000 (both inclusive), provided %d." % self.mtu
+            )
+        self.multicast_filtering_mode = self.module.params['multicast_filtering_mode']
         self.uplink_quantity = self.module.params['uplink_quantity']
-        self.discovery_proto = self.module.params['discovery_proto']
+        self.uplink_prefix = self.module.params['uplink_prefix']
+        self.discovery_protocol = self.module.params['discovery_proto']
         self.discovery_operation = self.module.params['discovery_operation']
+        # TODO: add port mirroring
+        self.health_check_vlan = self.params['health_check'].get('vlan_mtu')
+        self.health_check_vlan_interval = self.params['health_check'].get('vlan_mtu_interval')
+        self.health_check_teaming = self.params['health_check'].get('teaming_failover')
+        self.health_check_teaming_interval = self.params['health_check'].get('teaming_failover_interval')
+        if self.params['contact']:
+            self.contact_name = self.params['contact'].get('name')
+            self.contact_details = self.params['contact'].get('details')
+        else:
+            self.contact_name = None
+            self.contact_details = None
+        self.description = self.module.params['description']
         self.state = self.module.params['state']
-        self.content = connect_to_api(module)
 
     def process_state(self):
-        try:
-            dvs_states = {
-                'absent': {
-                    'present': self.state_destroy_dvs,
-                    'absent': self.state_exit_unchanged,
-                },
-                'present': {
-                    'update': self.state_update_dvs,
-                    'present': self.state_exit_unchanged,
-                    'absent': self.state_create_dvs,
-                }
+        """Process the current state of the DVS"""
+        dvs_states = {
+            'absent': {
+                'present': self.destroy_dvswitch,
+                'absent': self.exit_unchanged,
+            },
+            'present': {
+                'present': self.update_dvswitch,
+                'absent': self.create_dvswitch,
             }
-            dvs_states[self.state][self.check_dvs_configuration()]()
+        }
+
+        try:
+            dvs_states[self.state][self.check_dvs()]()
         except vmodl.RuntimeFault as runtime_fault:
-            self.module.fail_json(msg=runtime_fault.msg)
+            self.module.fail_json(msg=to_native(runtime_fault.msg))
         except vmodl.MethodFault as method_fault:
-            self.module.fail_json(msg=method_fault.msg)
+            self.module.fail_json(msg=to_native(method_fault.msg))
         except Exception as e:
-            self.module.fail_json(msg=str(e))
+            self.module.fail_json(msg=to_native(e))
 
-    def create_dvswitch(self, network_folder):
-        result = None
-        changed = False
-
-        spec = vim.DistributedVirtualSwitch.CreateSpec()
-        spec.configSpec = vim.dvs.VmwareDistributedVirtualSwitch.ConfigSpec()
-        spec.configSpec.uplinkPortPolicy = vim.DistributedVirtualSwitch.NameArrayUplinkPortPolicy()
-        spec.configSpec.linkDiscoveryProtocolConfig = vim.host.LinkDiscoveryProtocolConfig()
-
-        spec.configSpec.name = self.switch_name
-        spec.configSpec.maxMtu = self.mtu
-        spec.configSpec.linkDiscoveryProtocolConfig.protocol = self.discovery_proto
-        spec.configSpec.linkDiscoveryProtocolConfig.operation = self.discovery_operation
-        spec.productInfo = vim.dvs.ProductSpec()
-        spec.productInfo.name = "DVS"
-        spec.productInfo.vendor = "VMware"
-        spec.productInfo.version = self.switch_version
-
-        for count in range(1, self.uplink_quantity + 1):
-            spec.configSpec.uplinkPortPolicy.uplinkPortName.append("uplink%d" % count)
-
-        task = network_folder.CreateDVS_Task(spec)
-        changed, result = wait_for_task(task)
-        return changed, result
-
-    def state_exit_unchanged(self):
-        self.module.exit_json(changed=False)
-
-    def state_destroy_dvs(self):
-        task = self.dvs.Destroy_Task()
-        changed, result = wait_for_task(task)
-        self.module.exit_json(changed=changed, result=str(result))
-
-    def state_update_dvs(self):
-        self.module.exit_json(changed=False, msg="Currently not implemented.")
-
-    def state_create_dvs(self):
-        changed = True
-        result = None
-
-        if not self.module.check_mode:
-            dc = find_datacenter_by_name(self.content, self.datacenter_name)
-            changed, result = self.create_dvswitch(dc.networkFolder)
-
-        self.module.exit_json(changed=changed, result=str(result))
-
-    def check_dvs_configuration(self):
+    def check_dvs(self):
+        """Check if DVS is present"""
+        datacenter = find_datacenter_by_name(self.content, self.datacenter_name)
+        if datacenter is None:
+            self.module.fail_json(msg="Failed to find datacenter %s" % self.datacenter_name)
+        else:
+            self.datacenter = datacenter
         self.dvs = find_dvs_by_name(self.content, self.switch_name)
         if self.dvs is None:
             return 'absent'
+        return 'present'
+
+    def create_dvswitch(self):
+        """Create a DVS"""
+        changed = True
+        results = dict(changed=changed)
+
+        spec = vim.DistributedVirtualSwitch.CreateSpec()
+        spec.configSpec = vim.dvs.VmwareDistributedVirtualSwitch.ConfigSpec()
+        # Name
+        results['dvswitch'] = self.switch_name
+        spec.configSpec.name = self.switch_name
+        # MTU
+        results['mtu'] = self.mtu
+        spec.configSpec.maxMtu = self.mtu
+        # Discovery Protocol type and operation
+        results['discovery_protocol'] = self.discovery_protocol
+        results['discovery_operation'] = self.discovery_operation
+        spec.configSpec.linkDiscoveryProtocolConfig = self.create_ldp_spec()
+        # Administrator contact
+        results['contact'] = self.contact_name
+        results['contact_details'] = self.contact_details
+        if self.contact_name or self.contact_details:
+            spec.contact = self.create_contact_spec()
+        # Description
+        results['description'] = self.description
+        if self.description:
+            spec.description = self.description
+        # Uplinks
+        results['uplink_quantity'] = self.uplink_quantity
+        spec.configSpec.uplinkPortPolicy = vim.DistributedVirtualSwitch.NameArrayUplinkPortPolicy()
+        for count in range(1, self.uplink_quantity + 1):
+            spec.configSpec.uplinkPortPolicy.uplinkPortName.append("%s%d" % (self.uplink_prefix, count))
+        results['uplinks'] = spec.configSpec.uplinkPortPolicy.uplinkPortName
+        # Version
+        results['version'] = self.switch_version
+        if self.switch_version:
+            spec.productInfo = self.create_product_spec(self.switch_version)
+
+        if self.module.check_mode:
+            result = "DVS would be created"
         else:
-            return 'present'
+            # Create DVS
+            network_folder = self.datacenter.networkFolder
+            task = network_folder.CreateDVS_Task(spec)
+            try:
+                wait_for_task(task)
+            except TaskError as invalid_argument:
+                self.module.fail_json(
+                    msg="Failed to create DVS : %s" % to_native(invalid_argument)
+                )
+            # Find new DVS
+            self.dvs = find_dvs_by_name(self.content, self.switch_name)
+            changed_multicast = False
+            spec = vim.dvs.VmwareDistributedVirtualSwitch.ConfigSpec()
+            # Use the same version in the new spec; The version will be increased by one by the API automatically
+            spec.configVersion = self.dvs.config.configVersion
+            # Set multicast filtering mode
+            results['multicast_filtering_mode'] = self.multicast_filtering_mode
+            multicast_filtering_mode = self.get_api_mc_filtering_mode(self.multicast_filtering_mode)
+            if self.dvs.config.multicastFilteringMode != multicast_filtering_mode:
+                changed_multicast = True
+                spec.multicastFilteringMode = multicast_filtering_mode
+            spec.multicastFilteringMode = self.get_api_mc_filtering_mode(self.multicast_filtering_mode)
+            if changed_multicast:
+                self.update_dvs_config(self.dvs, spec)
+            # Set Health Check config
+            results['health_check_vlan'] = self.health_check_vlan
+            results['health_check_teaming'] = self.health_check_teaming
+            result = self.check_health_check_config(self.dvs.config.healthCheckConfig)
+            changed_health_check = result[1]
+            if changed_health_check:
+                self.update_health_check_config(self.dvs, result[0])
+            result = "DVS created"
+        self.module.exit_json(changed=changed, result=to_native(result))
+
+    def create_ldp_spec(self):
+        """Create Link Discovery Protocol config spec"""
+        ldp_config_spec = vim.host.LinkDiscoveryProtocolConfig()
+        if self.discovery_protocol == 'disabled':
+            ldp_config_spec.protocol = 'cdp'
+            ldp_config_spec.operation = 'none'
+        else:
+            ldp_config_spec.protocol = self.discovery_protocol
+            ldp_config_spec.operation = self.discovery_operation
+        return ldp_config_spec
+
+    def create_product_spec(self, switch_version):
+        """Create product info spec"""
+        product_info_spec = vim.dvs.ProductSpec()
+        product_info_spec.version = switch_version
+        return product_info_spec
+
+    @staticmethod
+    def get_api_mc_filtering_mode(mode):
+        """Get Multicast filtering mode"""
+        if mode == 'basic':
+            return 'legacyFiltering'
+        return 'snooping'
+
+    def create_contact_spec(self):
+        """Create contact info spec"""
+        contact_info_spec = vim.DistributedVirtualSwitch.ContactInfo()
+        contact_info_spec.name = self.contact_name
+        contact_info_spec.contact = self.contact_details
+        return contact_info_spec
+
+    def update_dvs_config(self, switch_object, spec):
+        """Update DVS config"""
+        try:
+            task = switch_object.ReconfigureDvs_Task(spec)
+            wait_for_task(task)
+        except TaskError as invalid_argument:
+            self.module.fail_json(
+                msg="Failed to update DVS : %s" % to_native(invalid_argument)
+            )
+
+    def check_health_check_config(self, health_check_config):
+        """Check Health Check config"""
+        changed = changed_vlan = changed_vlan_interval = changed_teaming = changed_teaming_interval = False
+        vlan_previous = teaming_previous = None
+        vlan_interval_previous = teaming_interval_previous = 0
+        for config in health_check_config:
+            if isinstance(config, vim.dvs.VmwareDistributedVirtualSwitch.VlanMtuHealthCheckConfig):
+                if config.enable != self.health_check_vlan:
+                    changed = changed_vlan = True
+                    vlan_previous = config.enable
+                    config.enable = self.health_check_vlan
+                if config.enable and config.interval != self.health_check_vlan_interval:
+                    changed = changed_vlan_interval = True
+                    vlan_interval_previous = config.interval
+                    config.interval = self.health_check_vlan_interval
+            if isinstance(config, vim.dvs.VmwareDistributedVirtualSwitch.TeamingHealthCheckConfig):
+                if config.enable != self.health_check_teaming:
+                    changed = changed_teaming = True
+                    teaming_previous = config.enable
+                    config.enable = self.health_check_teaming
+                if config.enable and config.interval != self.health_check_teaming_interval:
+                    changed = changed_teaming_interval = True
+                    teaming_interval_previous = config.interval
+                    config.interval = self.health_check_teaming_interval
+        return (health_check_config, changed, changed_vlan, vlan_previous, changed_vlan_interval, vlan_interval_previous,
+                changed_teaming, teaming_previous, changed_teaming_interval, teaming_interval_previous)
+
+    def update_health_check_config(self, switch_object, health_check_config):
+        """Update Health Check config"""
+        try:
+            task = switch_object.UpdateDVSHealthCheckConfig_Task(healthCheckConfig=health_check_config)
+        except vim.fault.DvsFault as dvs_fault:
+            self.module.fail_json(msg="Update failed due to DVS fault : %s" % to_native(dvs_fault))
+        except vmodl.fault.NotSupported as not_supported:
+            self.module.fail_json(msg="Health check not supported on the switch : %s" % to_native(not_supported))
+        except TaskError as invalid_argument:
+            self.module.fail_json(msg="Failed to configure health check : %s" % to_native(invalid_argument))
+        try:
+            wait_for_task(task)
+        except TaskError as invalid_argument:
+            self.module.fail_json(msg="Failed to update health check config : %s" % to_native(invalid_argument))
+
+    def exit_unchanged(self):
+        """Exit with status message"""
+        changed = False
+        results = dict(changed=changed)
+        results['dvswitch'] = self.switch_name
+        results['result'] = "DVS not present"
+        self.module.exit_json(**results)
+
+    def destroy_dvswitch(self):
+        """Delete a DVS"""
+        changed = True
+        results = dict(changed=changed)
+        results['dvswitch'] = self.switch_name
+        if self.module.check_mode:
+            results['result'] = "DVS would be deleted"
+        else:
+            try:
+                task = self.dvs.Destroy_Task()
+            except vim.fault.VimFault as vim_fault:
+                self.module.fail_json(msg="Failed to deleted DVS : %s" % to_native(vim_fault))
+            wait_for_task(task)
+            results['result'] = "DVS deleted"
+        self.module.exit_json(**results)
+
+    def update_dvswitch(self):
+        """Check and update DVS settings"""
+        changed = changed_settings = changed_ldp = changed_version = changed_health_check = False
+        results = dict(changed=changed)
+        results['dvswitch'] = self.switch_name
+        changed_list = []
+
+        config_spec = vim.dvs.VmwareDistributedVirtualSwitch.ConfigSpec()
+        # Use the same version in the new spec; The version will be increased by one by the API automatically
+        config_spec.configVersion = self.dvs.config.configVersion
+
+        # Check MTU
+        results['mtu'] = self.mtu
+        if self.dvs.config.maxMtu != self.mtu:
+            changed = changed_settings = True
+            changed_list.append("mtu")
+            results['mtu_previous'] = config_spec.maxMtu
+            config_spec.maxMtu = self.mtu
+
+        # Check Discovery Protocol type and operation
+        ldp_protocol = self.dvs.config.linkDiscoveryProtocolConfig.protocol
+        ldp_operation = self.dvs.config.linkDiscoveryProtocolConfig.operation
+        if self.discovery_protocol == 'disabled':
+            results['discovery_protocol'] = self.discovery_protocol
+            results['discovery_operation'] = 'n/a'
+            if ldp_protocol != 'cdp' or ldp_operation != 'none':
+                changed_ldp = True
+                results['discovery_protocol_previous'] = ldp_protocol
+                results['discovery_operation_previous'] = ldp_operation
+        else:
+            results['discovery_protocol'] = self.discovery_protocol
+            results['discovery_operation'] = self.discovery_operation
+            if ldp_protocol != self.discovery_protocol or ldp_operation != self.discovery_operation:
+                changed_ldp = True
+                if ldp_protocol != self.discovery_protocol:
+                    results['discovery_protocol_previous'] = ldp_protocol
+                if ldp_operation != self.discovery_operation:
+                    results['discovery_operation_previous'] = ldp_operation
+        if changed_ldp:
+            changed = changed_settings = True
+            changed_list.append("discovery protocol")
+            config_spec.linkDiscoveryProtocolConfig = self.create_ldp_spec()
+
+        # Check Multicast filtering mode
+        results['multicast_filtering_mode'] = self.multicast_filtering_mode
+        multicast_filtering_mode = self.get_api_mc_filtering_mode(self.multicast_filtering_mode)
+        if self.dvs.config.multicastFilteringMode != multicast_filtering_mode:
+            changed = changed_settings = True
+            changed_list.append("multicast filtering")
+            results['multicast_filtering_mode_previous'] = self.dvs.config.multicastFilteringMode
+            config_spec.multicastFilteringMode = multicast_filtering_mode
+
+        # Check administrator contact
+        results['contact'] = self.contact_name
+        results['contact_details'] = self.contact_details
+        if self.dvs.config.contact.name != self.contact_name or self.dvs.config.contact.contact != self.contact_details:
+            changed = changed_settings = True
+            changed_list.append("contact")
+            results['contact_previous'] = self.dvs.config.contact.name
+            results['contact_details_previous'] = self.dvs.config.contact.contact
+            config_spec.contact = self.create_contact_spec()
+
+        # Check description
+        results['description'] = self.description
+        if self.dvs.config.description != self.description:
+            changed = changed_settings = True
+            changed_list.append("description")
+            results['description_previous'] = self.dvs.config.description
+            if self.description is None:
+                # need to use empty string; will be set to None by API
+                config_spec.description = ''
+            else:
+                config_spec.description = self.description
+
+        # Check uplinks
+        results['uplink_quantity'] = self.uplink_quantity
+        if len(self.dvs.config.uplinkPortPolicy.uplinkPortName) != self.uplink_quantity:
+            changed = changed_settings = True
+            changed_list.append("uplink quantity")
+            results['uplink_quantity_previous'] = len(self.dvs.config.uplinkPortPolicy.uplinkPortName)
+            config_spec.uplinkPortPolicy = vim.DistributedVirtualSwitch.NameArrayUplinkPortPolicy()
+            # just replace the uplink array if uplinks need to be added
+            if len(self.dvs.config.uplinkPortPolicy.uplinkPortName) < self.uplink_quantity:
+                for count in range(1, self.uplink_quantity + 1):
+                    config_spec.uplinkPortPolicy.uplinkPortName.append("%s%d" % (self.uplink_prefix, count))
+            # just replace the uplink array if uplinks need to be removed
+            if len(self.dvs.config.uplinkPortPolicy.uplinkPortName) > self.uplink_quantity:
+                for count in range(1, self.uplink_quantity + 1):
+                    config_spec.uplinkPortPolicy.uplinkPortName.append("%s%d" % (self.uplink_prefix, count))
+            results['uplinks'] = config_spec.uplinkPortPolicy.uplinkPortName
+            results['uplinks_previous'] = self.dvs.config.uplinkPortPolicy.uplinkPortName
+        else:
+            # No uplink name check; uplink names can't be changed easily if they are used by a portgroup
+            results['uplinks'] = self.dvs.config.uplinkPortPolicy.uplinkPortName
+
+        # Check Health Check
+        results['health_check_vlan'] = self.health_check_vlan
+        results['health_check_teaming'] = self.health_check_teaming
+        results['health_check_vlan_interval'] = self.health_check_vlan_interval
+        results['health_check_teaming_interval'] = self.health_check_teaming_interval
+        (health_check_config, changed_health_check, changed_vlan, vlan_previous,
+         changed_vlan_interval, vlan_interval_previous, changed_teaming, teaming_previous,
+         changed_teaming_interval, teaming_interval_previous) = \
+            self.check_health_check_config(self.dvs.config.healthCheckConfig)
+        if changed_health_check:
+            changed = True
+            changed_list.append("health check")
+            if changed_vlan:
+                results['health_check_vlan_previous'] = vlan_previous
+            if changed_vlan_interval:
+                results['health_check_vlan_interval_previous'] = vlan_interval_previous
+            if changed_teaming:
+                results['health_check_teaming_previous'] = teaming_previous
+            if changed_teaming_interval:
+                results['health_check_teaming_interval_previous'] = teaming_interval_previous
+
+        # Check switch version
+        if self.switch_version:
+            results['version'] = self.switch_version
+            if self.dvs.config.productInfo.version != self.switch_version:
+                changed_version = True
+                spec_product = self.create_product_spec(self.switch_version)
+        else:
+            results['version'] = self.vcenter_switch_version
+            if self.dvs.config.productInfo.version != self.vcenter_switch_version:
+                changed_version = True
+                spec_product = self.create_product_spec(self.vcenter_switch_version)
+        if changed_version:
+            changed = True
+            changed_list.append("switch version")
+            results['version_previous'] = self.dvs.config.productInfo.version
+
+        if changed:
+            if self.module.check_mode:
+                changed_suffix = ' would be changed'
+            else:
+                changed_suffix = ' changed'
+            if len(changed_list) > 2:
+                message = ', '.join(changed_list[:-1]) + ', and ' + str(changed_list[-1])
+            elif len(changed_list) == 2:
+                message = ' and '.join(changed_list)
+            elif len(changed_list) == 1:
+                message = changed_list[0]
+            message += changed_suffix
+            if not self.module.check_mode:
+                if changed_settings:
+                    self.update_dvs_config(self.dvs, config_spec)
+                if changed_health_check:
+                    self.update_health_check_config(self.dvs, health_check_config)
+                if changed_version:
+                    task = self.dvs.PerformDvsProductSpecOperation_Task("upgrade", spec_product)
+                    try:
+                        wait_for_task(task)
+                    except TaskError as invalid_argument:
+                        self.module.fail_json(msg="Failed to update DVS version : %s" % to_native(invalid_argument))
+        else:
+            message = "DVS already configured properly"
+        results['changed'] = changed
+        results['result'] = message
+
+        self.module.exit_json(**results)
 
 
 def main():
+    """Main"""
     argument_spec = vmware_argument_spec()
-    argument_spec.update(dict(datacenter_name=dict(required=True, type='str'),
-                              switch_name=dict(required=True, type='str'),
-                              mtu=dict(required=True, type='int'),
-                              switch_version=dict(type='str'),
-                              uplink_quantity=dict(required=True, type='int'),
-                              discovery_proto=dict(required=True, choices=['cdp', 'lldp'], type='str'),
-                              discovery_operation=dict(required=True, choices=['both', 'none', 'advertise', 'listen'], type='str'),
-                              state=dict(default='present', choices=['present', 'absent'], type='str')))
+    argument_spec.update(
+        dict(
+            datacenter_name=dict(required=True, aliases=['datacenter']),
+            switch_name=dict(required=True, aliases=['switch', 'dvswitch']),
+            mtu=dict(type='int', default=1500),
+            multicast_filtering_mode=dict(type='str', default='basic', choices=['basic', 'snooping']),
+            switch_version=dict(
+                choices=['5.0.0', '5.1.0', '5.5.0', '6.0.0', '6.5.0', '6.6.0'],
+                aliases=['version'],
+                default=None
+            ),
+            uplink_quantity=dict(type='int'),
+            uplink_prefix=dict(type='str', default='Uplink '),
+            discovery_proto=dict(
+                type='str', choices=['cdp', 'lldp', 'disabled'], default='cdp', aliases=['discovery_protocol']
+            ),
+            discovery_operation=dict(type='str', choices=['both', 'advertise', 'listen'], default='listen'),
+            health_check=dict(
+                type='dict',
+                options=dict(
+                    vlan_mtu=dict(type='bool', default=False),
+                    teaming_failover=dict(type='bool', default=False),
+                    vlan_mtu_interval=dict(type='int', default=0),
+                    teaming_failover_interval=dict(type='int', default=0),
+                ),
+                default=dict(
+                    vlan_mtu=False,
+                    teaming_failover=False,
+                    vlan_mtu_interval=0,
+                    teaming_failover_interval=0,
+                ),
+            ),
+            contact=dict(
+                type='dict',
+                options=dict(
+                    name=dict(type='str'),
+                    description=dict(type='str'),
+                ),
+            ),
+            description=dict(type='str'),
+            state=dict(default='present', choices=['present', 'absent']),
+        )
+    )
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_if=[
+            ('state', 'present',
+             ['uplink_quantity']),
+        ],
+        supports_check_mode=True,
+    )
 
-    if not HAS_PYVMOMI:
-        module.fail_json(msg='pyvmomi is required for this module')
-
-    vmware_dvswitch = VMwareDVSwitch(module)
+    vmware_dvswitch = VMwareDvSwitch(module)
     vmware_dvswitch.process_state()
 
 

--- a/lib/ansible/modules/cloud/vmware/vmware_host_config_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_config_manager.py
@@ -42,6 +42,7 @@ options:
     description:
     - A dictionary of advanced system settings.
     - Invalid options will cause module to error.
+    - Note that the list of advanced options (with description and values) can be found by running `vim-cmd hostsvc/advopt/options`.
     default: {}
 extends_documentation_fragment: vmware.documentation
 '''

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -51,6 +51,8 @@ notes:
       M(acme_challenge_cert_helper) module to prepare the challenge certificate."
    - "You can use the M(certificate_complete_chain) module to find the root certificate
       for the returned fullchain."
+   - "In case you want to debug problems, you might be interested in the M(acme_inspect)
+      module."
 extends_documentation_fragment:
   - acme
 options:

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -167,7 +167,7 @@ options:
     version_added: 2.6
 '''
 
-EXAMPLES = R'''
+EXAMPLES = r'''
 ### Example with HTTP challenge ###
 
 - name: Create a challenge for sample.com using a account key from a variable.

--- a/lib/ansible/modules/crypto/acme/acme_inspect.py
+++ b/lib/ansible/modules/crypto/acme/acme_inspect.py
@@ -1,0 +1,319 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2018 Felix Fontein (@felixfontein)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = r'''
+---
+module: acme_inspect
+author: "Felix Fontein (@felixfontein)"
+version_added: "2.8"
+short_description: Send direct requests to an ACME server
+description:
+   - "Allows to send direct requests to an ACME server with the
+      L(ACME protocol,https://tools.ietf.org/html/draft-ietf-acme-acme-14),
+      which is supported by CAs such as L(Let's Encrypt,https://letsencrypt.org/)."
+   - "This module can be used to debug failed certificate request attempts,
+      for example when M(acme_certificate) fails or encounters a problem which
+      you wish to investigate."
+   - "The module can also be used to directly access features of an ACME servers
+      which are not yet supported by the Ansible ACME modules."
+notes:
+   - "The I(account_uri) option must be specified for properly authenticated
+      ACME v2 requests (except a C(new-account) request)."
+   - "Using the C(ansible) tool, M(acme_inspect) can be used to directly execute
+      ACME requests without the need of writing a playbook. For example, the
+      following command retrieves the ACME account with ID 1 from Let's Encrypt
+      (assuming C(/path/to/key) is the correct private account key):
+      C(ansible localhost -m acme_inspect -a \"account_key_src=/path/to/key
+      acme_directory=https://acme-v02.api.letsencrypt.org/directory acme_version=2
+      account_uri=https://acme-v02.api.letsencrypt.org/acme/acct/1 method=get
+      url=https://acme-v02.api.letsencrypt.org/acme/acct/1\")"
+extends_documentation_fragment:
+  - acme
+options:
+  url:
+    description:
+      - "The URL to send the request to."
+      - "Must be specified if I(method) is not C(directory-only)."
+    type: str
+  method:
+    description:
+      - "The method to use to access the given URL on the ACME server."
+      - "The value C(post) executes an authenticated POST request. The content
+         must be specified in the I(content) option."
+      - "The value C(get) executes an authenticated POST-as-GET request for ACME v2,
+         and a regular GET request for ACME v1."
+      - "The value C(directory-only) only retrieves the directory, without doing
+         a request."
+    choices:
+    - get
+    - post
+    - directory-only
+    default: get
+  content:
+    description:
+      - "An encoded JSON object which will be sent as the content if I(method)
+         is C(post)."
+      - "Required when I(method) is C(post), and not allowed otherwise."
+    type: str
+  fail_on_acme_error:
+    description:
+      - "If I(method) is C(post) or C(get), make the module fail in case an ACME
+         error is returned."
+    type: bool
+    default: yes
+'''
+
+EXAMPLES = r'''
+- name: Get directory
+  acme_inspect:
+    acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
+    acme_version: 2
+    method: directory-only
+  register: directory
+
+- name: Create an account
+  acme_inspect:
+    acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
+    acme_version: 2
+    account_key_src: /etc/pki/cert/private/account.key
+    url: "{{ directory.newAccount}}"
+    method: post
+    content: '{"termsOfServiceAgreed":true}'
+  register: account_creation
+  # account_creation.headers.location contains the account URI
+  # if creation was successful
+
+- name: Get account information
+  acme_inspect:
+    acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
+    acme_version: 2
+    account_key_src: /etc/pki/cert/private/account.key
+    account_uri: "{{ account_creation.headers.location }}"
+    url: "{{ account_creation.headers.location }}"
+    method: get
+
+- name: Update account contacts
+  acme_inspect:
+    acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
+    acme_version: 2
+    account_key_src: /etc/pki/cert/private/account.key
+    account_uri: "{{ account_creation.headers.location }}"
+    url: "{{ account_creation.headers.location }}"
+    method: post
+    content: '{{ account_info | to_json }}'
+  vars:
+    account_info:
+      # For valid values, see
+      # https://tools.ietf.org/html/draft-ietf-acme-acme-16#section-7.3
+      contact:
+      - mailto:me@example.com
+
+- name: Create certificate order
+  acme_certificate:
+    acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
+    acme_version: 2
+    account_key_src: /etc/pki/cert/private/account.key
+    account_uri: "{{ account_creation.headers.location }}"
+    csr: /etc/pki/cert/csr/sample.com.csr
+    fullchain_dest: /etc/httpd/ssl/sample.com-fullchain.crt
+    challenge: http-01
+  register: certificate_request
+
+# Assume something went wrong. certificate_request.order_uri contains
+# the order URI.
+
+- name: Get order information
+  acme_inspect:
+    acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
+    acme_version: 2
+    account_key_src: /etc/pki/cert/private/account.key
+    account_uri: "{{ account_creation.headers.location }}"
+    url: "{{ certificate_request.order_uri }}"
+    method: get
+  register: order
+
+- name: Get first authz for order
+  acme_inspect:
+    acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
+    acme_version: 2
+    account_key_src: /etc/pki/cert/private/account.key
+    account_uri: "{{ account_creation.headers.location }}"
+    url: "{{ order.output_json.authorizations[0] }}"
+    method: get
+  register: authz
+
+- name: Get HTTP-01 challenge for authz
+  acme_inspect:
+    acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
+    acme_version: 2
+    account_key_src: /etc/pki/cert/private/account.key
+    account_uri: "{{ account_creation.headers.location }}"
+    url: "{{ authz.output_json.challenges | selectattr('type', 'equalto', 'http-01') }}"
+    method: get
+  register: http01challenge
+
+- name: Activate HTTP-01 challenge manually
+  acme_inspect:
+    acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
+    acme_version: 2
+    account_key_src: /etc/pki/cert/private/account.key
+    account_uri: "{{ account_creation.headers.location }}"
+    url: "{{ http01challenge.url }}"
+    method: post
+    content: '{}'
+'''
+
+RETURN = '''
+directory:
+  description: The ACME directory's content
+  returned: always
+  type: dict
+  sample: |
+    {
+      "a85k3x9f91A4": "https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417",
+      "keyChange": "https://acme-v02.api.letsencrypt.org/acme/key-change",
+      "meta": {
+          "caaIdentities": [
+              "letsencrypt.org"
+          ],
+          "termsOfService": "https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf",
+          "website": "https://letsencrypt.org"
+      },
+      "newAccount": "https://acme-v02.api.letsencrypt.org/acme/new-acct",
+      "newNonce": "https://acme-v02.api.letsencrypt.org/acme/new-nonce",
+      "newOrder": "https://acme-v02.api.letsencrypt.org/acme/new-order",
+      "revokeCert": "https://acme-v02.api.letsencrypt.org/acme/revoke-cert"
+    }
+headers:
+  description: The request's HTTP headers (with lowercase keys)
+  returned: always
+  type: dict
+  sample: |
+    {
+      "boulder-requester": "12345",
+      "cache-control": "max-age=0, no-cache, no-store",
+      "connection": "close",
+      "content-length": "904",
+      "content-type": "application/json",
+      "cookies": {},
+      "cookies_string": "",
+      "date": "Wed, 07 Nov 2018 12:34:56 GMT",
+      "expires": "Wed, 07 Nov 2018 12:44:56 GMT",
+      "link": "<https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf>;rel=\"terms-of-service\"",
+      "msg": "OK (904 bytes)",
+      "pragma": "no-cache",
+      "replay-nonce": "1234567890abcdefghijklmnopqrstuvwxyzABCDEFGH",
+      "server": "nginx",
+      "status": 200,
+      "strict-transport-security": "max-age=604800",
+      "url": "https://acme-v02.api.letsencrypt.org/acme/acct/46161",
+      "x-frame-options": "DENY"
+    }
+output_text:
+  description: The raw text output
+  returned: always
+  type: string
+  sample: "{\\n  \\\"id\\\": 12345,\\n  \\\"key\\\": {\\n    \\\"kty\\\": \\\"RSA\\\",\\n ..."
+output_json:
+  description: The output parsed as JSON
+  returned: if output can be parsed as JSON
+  type: dict
+  sample:
+    - id: 12345
+    - key:
+      - kty: RSA
+      - ...
+'''
+
+from ansible.module_utils.acme import (
+    ModuleFailException, ACMEAccount, set_crypto_backend,
+)
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native, to_bytes
+
+import json
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            account_key_src=dict(type='path', aliases=['account_key']),
+            account_key_content=dict(type='str', no_log=True),
+            account_uri=dict(required=False, type='str'),
+            acme_directory=dict(required=False, default='https://acme-staging.api.letsencrypt.org/directory', type='str'),
+            acme_version=dict(required=False, default=1, choices=[1, 2], type='int'),
+            validate_certs=dict(required=False, default=True, type='bool'),
+            url=dict(required=False, type='str'),
+            method=dict(required=False, type='str', choices=['get', 'post', 'directory-only'], default='get'),
+            content=dict(required=False, type='str'),
+            fail_on_acme_error=dict(required=False, type='bool', default=True),
+            select_crypto_backend=dict(required=False, choices=['auto', 'openssl', 'cryptography'], default='auto', type='str'),
+        ),
+        mutually_exclusive=(
+            ['account_key_src', 'account_key_content'],
+        ),
+        required_if=(
+            ['method', 'get', ['url']],
+            ['method', 'post', ['url', 'content']],
+            ['method', 'get', ['account_key_src', 'account_key_content'], True],
+            ['method', 'post', ['account_key_src', 'account_key_content'], True],
+        ),
+    )
+    set_crypto_backend(module)
+
+    if not module.params.get('validate_certs'):
+        module.warn(warning='Disabling certificate validation for communications with ACME endpoint. ' +
+                            'This should only be done for testing against a local ACME server for ' +
+                            'development purposes, but *never* for production purposes.')
+
+    result = dict()
+    changed = False
+    try:
+        # Get hold of ACMEAccount object (includes directory)
+        account = ACMEAccount(module)
+        method = module.params['method']
+        result['directory'] = account.directory.directory
+        # Do we have to do more requests?
+        if method != 'directory-only':
+            url = module.params['url']
+            fail_on_acme_error = module.params['fail_on_acme_error']
+            # Do request
+            if method == 'get':
+                data, info = account.get_request(url, parse_json_result=False, fail_on_error=False)
+            elif method == 'post':
+                changed = True  # only POSTs can change
+                data, info = account.send_signed_request(url, to_bytes(module.params['content']), parse_json_result=False, encode_payload=False)
+            # Update results
+            result.update(dict(
+                headers=info,
+                output_text=to_native(data),
+            ))
+            # See if we can parse the result as JSON
+            try:
+                result['output_json'] = json.loads(data)
+            except Exception as dummy:
+                pass
+            # Fail if error was returned
+            if fail_on_acme_error and info['status'] >= 400:
+                raise ModuleFailException("ACME request failed: CODE: {0} RESULT: {1}".format(info['status'], data))
+        # Done!
+        module.exit_json(changed=changed, **result)
+    except ModuleFailException as e:
+        e.do_fail(module, **result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/files/patch.py
+++ b/lib/ansible/modules/files/patch.py
@@ -100,7 +100,7 @@ EXAMPLES = r'''
 
 import os
 from traceback import format_exc
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, get_platform
 from ansible.module_utils._text import to_native
 
 
@@ -108,10 +108,19 @@ class PatchError(Exception):
     pass
 
 
+def add_dry_run_option(opts):
+    # Older versions of FreeBSD, OpenBSD and NetBSD support the --check option only.
+    if get_platform().lower() in ['openbsd', 'netbsd', 'freebsd']:
+        opts.append('--check')
+    else:
+        opts.append('--dry-run')
+
+
 def is_already_applied(patch_func, patch_file, basedir, dest_file=None, binary=False, strip=0, state='present'):
-    opts = ['--quiet', '--forward', '--dry-run',
+    opts = ['--quiet', '--forward',
             "--strip=%s" % strip, "--directory='%s'" % basedir,
             "--input='%s'" % patch_file]
+    add_dry_run_option(opts)
     if binary:
         opts.append('--binary')
     if dest_file:
@@ -128,7 +137,7 @@ def apply_patch(patch_func, patch_file, basedir, dest_file=None, binary=False, s
             "--strip=%s" % strip, "--directory='%s'" % basedir,
             "--input='%s'" % patch_file]
     if dry_run:
-        opts.append('--dry-run')
+        add_dry_run_option(opts)
     if binary:
         opts.append('--binary')
     if dest_file:

--- a/lib/ansible/modules/files/tempfile.py
+++ b/lib/ansible/modules/files/tempfile.py
@@ -55,6 +55,13 @@ EXAMPLES = """
   tempfile:
     state: file
     suffix: temp
+  register: tempfile_1
+
+- name: use the registered var and the file module to remove the temporary file
+  file:
+    path: "{{ tempfile_1.path }}"
+    state: absent
+  when: tempfile_1.path is defined
 """
 
 RETURN = '''

--- a/lib/ansible/modules/identity/ipa/ipa_user.py
+++ b/lib/ansible/modules/identity/ipa/ipa_user.py
@@ -194,7 +194,10 @@ def get_user_diff(client, ipa_user, module_user):
     # These are used for comparison.
     sshpubkey = None
     if 'ipasshpubkey' in module_user:
-        module_user['sshpubkeyfp'] = [get_ssh_key_fingerprint(pubkey) for pubkey in module_user['ipasshpubkey']]
+        hash_algo = 'md5'
+        if 'sshpubkeyfp' in ipa_user and ipa_user['sshpubkeyfp'][0][:7].upper() == 'SHA256:':
+            hash_algo = 'sha256'
+        module_user['sshpubkeyfp'] = [get_ssh_key_fingerprint(pubkey, hash_algo) for pubkey in module_user['ipasshpubkey']]
         # Remove the ipasshpubkey element as it is not returned from IPA but save it's value to be used later on
         sshpubkey = module_user['ipasshpubkey']
         del module_user['ipasshpubkey']
@@ -208,11 +211,16 @@ def get_user_diff(client, ipa_user, module_user):
     return result
 
 
-def get_ssh_key_fingerprint(ssh_key):
+def get_ssh_key_fingerprint(ssh_key, hash_algo='sha256'):
     """
     Return the public key fingerprint of a given public SSH key
-    in format "FB:0C:AC:0A:07:94:5B:CE:75:6E:63:32:13:AD:AD:D7 [user@host] (ssh-rsa)"
+    in format "[fp] [user@host] (ssh-rsa)" where fp is of the format:
+    FB:0C:AC:0A:07:94:5B:CE:75:6E:63:32:13:AD:AD:D7
+    for md5 or
+    SHA256:[base64]
+    for sha256
     :param ssh_key:
+    :param hash_algo:
     :return:
     """
     parts = ssh_key.strip().split()
@@ -221,8 +229,12 @@ def get_ssh_key_fingerprint(ssh_key):
     key_type = parts[0]
     key = base64.b64decode(parts[1].encode('ascii'))
 
-    fp_plain = hashlib.md5(key).hexdigest()
-    key_fp = ':'.join(a + b for a, b in zip(fp_plain[::2], fp_plain[1::2])).upper()
+    if hash_algo == 'md5':
+        fp_plain = hashlib.md5(key).hexdigest()
+        key_fp = ':'.join(a + b for a, b in zip(fp_plain[::2], fp_plain[1::2])).upper()
+    elif hash_algo == 'sha256':
+        fp_plain = base64.b64encode(hashlib.sha256(key).digest()).decode('ascii').rstrip('=')
+        key_fp = 'SHA256:{fp}'.format(fp=fp_plain)
     if len(parts) < 3:
         return "%s (%s)" % (key_fp, key_type)
     else:

--- a/lib/ansible/modules/monitoring/grafana_datasource.py
+++ b/lib/ansible/modules/monitoring/grafana_datasource.py
@@ -17,6 +17,7 @@ DOCUMENTATION = '''
 module: grafana_datasource
 author:
   - Thierry Sallé (@seuf)
+  - Martin Wang (@martinwangjian)
 version_added: "2.5"
 short_description: Manage Grafana datasources
 description:
@@ -34,7 +35,7 @@ options:
     description:
      - The type of the datasource.
     required: true
-    choices: [ graphite, prometheus, elasticsearch, influxdb, opentsdb, mysql, postgres, alexanderzobnin-zabbix-datasource]
+    choices: [ graphite, prometheus, elasticsearch, influxdb, opentsdb, mysql, postgres, cloudwatch, alexanderzobnin-zabbix-datasource]
   url:
     description:
       - The URL of the datasource.
@@ -183,6 +184,56 @@ options:
     default: 'yes'
     type: bool
     version_added: 2.8
+  aws_auth_type:
+    description:
+      - Type for AWS authentication for CloudWatch datasource type (authType of grafana api)
+    default: 'keys'
+    choices: [ keys, credentials, arn ]
+    version_added: 2.8
+  aws_default_region:
+    description:
+      - AWS default region for CloudWatch datasource type
+    default: 'us-east-1'
+    choices: [
+      ap-northeast-1, ap-northeast-2, ap-southeast-1, ap-southeast-2, ap-south-1,
+      ca-central-1,
+      cn-north-1, cn-northwest-1,
+      eu-central-1, eu-west-1, eu-west-2, eu-west-3,
+      sa-east-1,
+      us-east-1, us-east-2, us-gov-west-1, us-west-1, us-west-2
+    ]
+    version_added: 2.8
+  aws_credentials_profile:
+    description:
+      - Profile for AWS credentials for CloudWatch datasource type when C(aws_auth_type) is C(credentials)
+    default: ''
+    required: false
+    version_added: 2.8
+  aws_access_key:
+    description:
+      - AWS access key for CloudWatch datasource type when C(aws_auth_type) is C(keys)
+    default: ''
+    required: false
+    version_added: 2.8
+  aws_secret_key:
+    description:
+      - AWS secret key for CloudWatch datasource type when C(aws_auth_type) is C(keys)
+    default: ''
+    required: false
+    version_added: 2.8
+  aws_assume_role_arn:
+    description:
+      - AWS IAM role arn to assume for CloudWatch datasource type when C(aws_auth_type) is C(arn)
+    default: ''
+    required: false
+    version_added: 2.8
+  aws_custom_metrics_namespaces:
+    description:
+      - Namespaces of Custom Metrics for CloudWatch datasource type
+    default: ''
+    required: false
+    version_added: 2.8
+
 '''
 
 EXAMPLES = '''
@@ -218,6 +269,35 @@ EXAMPLES = '''
     database: "telegraf"
     time_interval: ">10s"
     tls_ca_cert: "/etc/ssl/certs/ca.pem"
+
+- name: Create postgres datasource
+  grafana_datasource:
+    name: "datasource-postgres"
+    grafana_url: "https://grafana.company.com"
+    grafana_user: "admin"
+    grafana_password: "xxxxxx"
+    org_id: "1"
+    ds_type: "postgres"
+    ds_url: "postgres.company.com:5432"
+    database: "db"
+    user: "postgres"
+    password: "iampgroot"
+    sslmode: "verify-full"
+
+- name: Create cloudwatch datasource
+  grafana_datasource:
+    name: "datasource-cloudwatch"
+    grafana_url: "https://grafana.company.com"
+    grafana_user: "admin"
+    grafana_password: "xxxxxx"
+    org_id: "1"
+    ds_type: "cloudwatch"
+    url: "http://monitoring.us-west-1.amazonaws.com"
+    aws_auth_type: "keys"
+    aws_default_region: "us-west-1"
+    aws_access_key: "speakFriendAndEnter"
+    aws_secret_key: "mel10n"
+    aws_custom_metrics_namespaces: "n1,n2"
 '''
 
 RETURN = '''
@@ -400,6 +480,20 @@ def grafana_create_datasource(module, data):
         if data.get('trends'):
             json_data['trends'] = True
 
+    if data['ds_type'] == 'cloudwatch':
+        if data.get('aws_credentials_profle'):
+            payload['database'] = data.get('aws_credentials_profile')
+
+        json_data['authType'] = data['aws_auth_type']
+        json_data['defaultRegion'] = data['aws_default_region']
+
+        if data.get('aws_custom_metrics_namespaces'):
+            json_data['customMetricsNamespaces'] = data.get('aws_custom_metrics_namespaces')
+        if data.get('aws_assume_role_arn'):
+            json_data['assumeRoleArn'] = data.get('aws_assume_role_arn')
+        if data.get('aws_access_key') and data.get('aws_secret_key'):
+            payload['secureJsonData'] = {'accessKey': data.get('aws_access_key'), 'secretKey': data.get('aws_secret_key')}
+
     payload['jsonData'] = json_data
 
     # define http header
@@ -509,6 +603,7 @@ def main():
                               'opentsdb',
                               'mysql',
                               'postgres',
+                              'cloudwatch',
                               'alexanderzobnin-zabbix-datasource']),
         url=dict(required=True, type='str', aliases=['ds_url']),
         access=dict(default='proxy', choices=['proxy', 'direct']),
@@ -534,6 +629,18 @@ def main():
         tsdb_resolution=dict(type='str', default='second', choices=['second', 'millisecond']),
         sslmode=dict(default='disable', choices=['disable', 'require', 'verify-ca', 'verify-full']),
         trends=dict(default=False, type='bool'),
+        aws_auth_type=dict(default='keys', choices=['keys', 'credentials', 'arn']),
+        aws_default_region=dict(default='us-east-1', choices=['ap-northeast-1', 'ap-northeast-2', 'ap-southeast-1', 'ap-southeast-2', 'ap-south-1',
+                                                              'ca-central-1',
+                                                              'cn-north-1', 'cn-northwest-1',
+                                                              'eu-central-1', 'eu-west-1', 'eu-west-2', 'eu-west-3',
+                                                              'sa-east-1',
+                                                              'us-east-1', 'us-east-2', 'us-gov-west-1', 'us-west-1', 'us-west-2']),
+        aws_access_key=dict(default='', no_log=True, type='str'),
+        aws_secret_key=dict(default='', no_log=True, type='str'),
+        aws_credentials_profile=dict(default='', type='str'),
+        aws_assume_role_arn=dict(default='', type='str'),
+        aws_custom_metrics_namespaces=dict(type='str'),
     )
 
     module = AnsibleModule(
@@ -547,6 +654,7 @@ def main():
             ['ds_type', 'elasticsearch', ['database', 'es_version', 'time_field', 'interval']],
             ['ds_type', 'mysql', ['database']],
             ['ds_type', 'postgres', ['database', 'sslmode']],
+            ['ds_type', 'cloudwatch', ['aws_auth_type', 'aws_default_region']],
             ['es_version', 56, ['max_concurrent_shard_requests']]
         ],
     )

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -1,21 +1,9 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+
 # (c) 2017, sookido
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
@@ -26,7 +14,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 
 DOCUMENTATION = '''
-
+---
 module: zabbix_template
 short_description: create/delete/dump zabbix template
 description:
@@ -174,6 +162,7 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
+---
 template_json:
   description: The JSON dump of the template
   returned: when state is dump
@@ -350,6 +339,18 @@ class Template(object):
         unwanted_keys = set(template_json['zabbix_export']) - keep_keys
         for unwanted_key in unwanted_keys:
             del template_json['zabbix_export'][unwanted_key]
+
+        # Versions older than 2.4 do not support description field within template
+        desc_not_supported = False
+        if LooseVersion(self._zapi.api_version()).version[:2] < LooseVersion('2.4').version:
+            desc_not_supported = True
+
+        # Filter empty attributes from template object to allow accurate comparison
+        for template in template_json['zabbix_export']['templates']:
+            for key in template.keys():
+                if not template[key] or (key == 'description' and desc_not_supported):
+                    template.pop(key)
+
         return template_json
 
     def load_json_template(self, template_json):
@@ -516,7 +517,12 @@ def main():
     elif state == "present":
         child_template_ids = None
         if link_templates is not None:
-            child_template_ids = template.get_template_ids(link_templates)
+            existing_child_templates = None
+            if existing_template_json:
+                existing_child_templates = set(list(
+                    tmpl['name'] for tmpl in existing_template_json['zabbix_export']['templates'][0]['templates']))
+            if not existing_template_json or set(link_templates) != existing_child_templates:
+                child_template_ids = template.get_template_ids(link_templates)
 
         clear_template_ids = []
         if clear_templates is not None:
@@ -534,9 +540,14 @@ def main():
         macros = None
         if template_macros is not None:
             existing_macros = None
+            # zabbix configuration.export does not differentiate python types (numbers are returned as strings)
+            for macroitem in template_macros:
+                for key in macroitem:
+                    macroitem[key] = str(macroitem[key])
+
             if existing_template_json:
-                existing_macros = set(existing_template_json['zabbix_export']['templates'][0]['macros'])
-            if not existing_macros or set(template_macros) != existing_macros:
+                existing_macros = existing_template_json['zabbix_export']['templates'][0]['macros']
+            if not existing_macros or template_macros != existing_macros:
                 macros = template_macros
 
         if not template_ids:
@@ -551,7 +562,7 @@ def main():
                                                clear_template_ids, macros,
                                                existing_template_json)
             module.exit_json(changed=changed,
-                             result="Successfully updateed template: %s" %
+                             result="Successfully updated template: %s" %
                              template_name)
 
 

--- a/lib/ansible/modules/network/dellos10/dellos10_command.py
+++ b/lib/ansible/modules/network/dellos10/dellos10_command.py
@@ -20,12 +20,12 @@ version_added: "2.2"
 author: "Senthil Kumar Ganesan (@skg-net)"
 short_description: Run commands on remote devices running Dell OS10
 description:
-  - Sends arbitrary commands to a Dell OS10 node and returns the results
+  - Sends arbitrary commands to a Dell EMC OS10 node and returns the results
     read from the device. This module includes an
     argument that will cause the module to wait for a specific condition
     before returning or timing out if the condition is not met.
   - This module does not support running commands in configuration mode.
-    Please use M(dellos10_config) to configure Dell OS10 devices.
+    Please use M(dellos10_config) to configure Dell EMC OS10 devices.
 extends_documentation_fragment: dellos10
 options:
   commands:

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -142,7 +142,9 @@ ansible_net_interfaces:
   returned: when interfaces is configured
   type: dict
 ansible_net_neighbors:
-  description: The list of LLDP neighbors from the remote device
+  description:
+    - The list of CDP and LLDP neighbors from the remote device. If both,
+      CDP and LLDP neighbor data is present on one port, CDP is preferred.
   returned: when interfaces is configured
   type: dict
 """
@@ -150,6 +152,7 @@ import re
 
 from ansible.module_utils.network.ios.ios import run_commands
 from ansible.module_utils.network.ios.ios import ios_argument_spec, check_args
+from ansible.module_utils.network.ios.ios import normalize_interface
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import iteritems
 from ansible.module_utils.six.moves import zip
@@ -294,7 +297,8 @@ class Interfaces(FactsBase):
         'show interfaces',
         'show ip interface',
         'show ipv6 interface',
-        'show lldp'
+        'show lldp',
+        'show cdp'
     ]
 
     def populate(self):
@@ -302,6 +306,7 @@ class Interfaces(FactsBase):
 
         self.facts['all_ipv4_addresses'] = list()
         self.facts['all_ipv6_addresses'] = list()
+        self.facts['neighbors'] = {}
 
         data = self.responses[0]
         if data:
@@ -324,7 +329,15 @@ class Interfaces(FactsBase):
         if data and not any(err in data for err in lldp_errs):
             neighbors = self.run(['show lldp neighbors detail'])
             if neighbors:
-                self.facts['neighbors'] = self.parse_neighbors(neighbors[0])
+                self.facts['neighbors'].update(self.parse_neighbors(neighbors[0]))
+
+        data = self.responses[4]
+        cdp_errs = ['CDP is not enabled']
+
+        if data and not any(err in data for err in cdp_errs):
+            cdp_neighbors = self.run(['show cdp neighbors detail'])
+            if cdp_neighbors:
+                self.facts['neighbors'].update(self.parse_cdp_neighbors(cdp_neighbors[0]))
 
     def populate_interfaces(self, interfaces):
         facts = dict()
@@ -387,11 +400,29 @@ class Interfaces(FactsBase):
             intf = self.parse_lldp_intf(entry)
             if intf is None:
                 return facts
+            intf = normalize_interface(intf)
             if intf not in facts:
                 facts[intf] = list()
             fact = dict()
             fact['host'] = self.parse_lldp_host(entry)
             fact['port'] = self.parse_lldp_port(entry)
+            facts[intf].append(fact)
+        return facts
+
+    def parse_cdp_neighbors(self, neighbors):
+        facts = dict()
+        for entry in neighbors.split('-------------------------'):
+            if entry == '':
+                continue
+            intf_port = self.parse_cdp_intf_port(entry)
+            if intf_port is None:
+                return facts
+            intf, port = intf_port
+            if intf not in facts:
+                facts[intf] = list()
+            fact = dict()
+            fact['host'] = self.parse_cdp_host(entry)
+            fact['port'] = port
             facts[intf].append(fact)
         return facts
 
@@ -473,6 +504,16 @@ class Interfaces(FactsBase):
 
     def parse_lldp_port(self, data):
         match = re.search(r'Port id: (.+)$', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_cdp_intf_port(self, data):
+        match = re.search(r'^Interface: (.+),  Port ID \(outgoing port\): (.+)$', data, re.M)
+        if match:
+            return match.group(1), match.group(2)
+
+    def parse_cdp_host(self, data):
+        match = re.search(r'^Device ID: (.+)$', data, re.M)
         if match:
             return match.group(1)
 

--- a/lib/ansible/modules/network/netvisor/pn_access_list.py
+++ b/lib/ansible/modules/network/netvisor/pn_access_list.py
@@ -1,0 +1,173 @@
+#!/usr/bin/python
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: pn_access_list
+author: "Pluribus Networks (@amitsi)"
+version_added: "2.8"
+short_description: CLI command to create/delete access-list
+description:
+  - This module can be used to create and delete an access list.
+options:
+  pn_cliswitch:
+    description:
+      - Target switch to run the CLI on.
+    required: False
+    type: str
+  state:
+    description:
+      - State the action to perform. Use 'present' to create access-list and
+        'absent' to delete access-list.
+    required: True
+    choices: [ "present", "absent"]
+  pn_name:
+    description:
+      - Access List Name.
+    required: false
+    type: str
+  pn_scope:
+    description:
+      - 'scope. Available valid values - local or fabric.'
+    required: false
+    choices: ['local', 'fabric']
+"""
+
+EXAMPLES = """
+- name: access list functionality
+  pn_access_list:
+    pn_cliswitch: "sw01"
+    pn_name: "foo"
+    pn_scope: "local"
+    state: "present"
+
+- name: access list functionality
+  pn_access_list:
+    pn_cliswitch: "sw01"
+    pn_name: "foo"
+    pn_scope: "local"
+    state: "absent"
+
+- name: access list functionality
+  pn_access_list:
+    pn_cliswitch: "sw01"
+    pn_name: "foo"
+    pn_scope: "fabric"
+    state: "present"
+"""
+
+RETURN = """
+command:
+  description: the CLI command run on the target node.
+  returned: always
+  type: string
+stdout:
+  description: set of responses from the access-list command.
+  returned: always
+  type: list
+stderr:
+  description: set of error responses from the access-list command.
+  returned: on error
+  type: list
+changed:
+  description: indicates whether the CLI caused changes on the target.
+  returned: always
+  type: bool
+"""
+
+import shlex
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+
+
+def check_cli(module, cli):
+    """
+    This method checks for idempotency using the access-list-show command.
+    If a list with given name exists, return ACC_LIST_EXISTS
+    as True else False.
+    :param module: The Ansible module to fetch input parameters
+    :param cli: The CLI string
+    :return Global Booleans: ACC_LIST_EXISTS
+    """
+    list_name = module.params['pn_name']
+
+    show = cli + \
+        ' access-list-show format name no-show-headers'
+    show = shlex.split(show)
+    out = module.run_command(show)[1]
+
+    out = out.split()
+    # Global flags
+    global ACC_LIST_EXISTS
+
+    ACC_LIST_EXISTS = True if list_name in out else False
+
+
+def main():
+    """ This section is for arguments parsing """
+
+    global state_map
+    state_map = dict(
+        present='access-list-create',
+        absent='access-list-delete',
+    )
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            pn_cliswitch=dict(required=False, type='str'),
+            state=dict(required=True, type='str',
+                       choices=state_map.keys()),
+            pn_name=dict(required=False, type='str'),
+            pn_scope=dict(required=False, type='str',
+                          choices=['local', 'fabric']),
+        ),
+        required_if=(
+            ["state", "present", ["pn_name", "pn_scope"]],
+            ["state", "absent", ["pn_name"]],
+        ),
+    )
+
+    # Accessing the arguments
+    cliswitch = module.params['pn_cliswitch']
+    state = module.params['state']
+    list_name = module.params['pn_name']
+    scope = module.params['pn_scope']
+
+    command = state_map[state]
+
+    # Building the CLI command string
+    cli = pn_cli(module, cliswitch)
+
+    check_cli(module, cli)
+    cli += ' %s name %s ' % (command, list_name)
+
+    if command == 'access-list-delete':
+        if ACC_LIST_EXISTS is False:
+            module.exit_json(
+                skipped=True,
+                msg='access-list with name %s does not exist' % list_name
+            )
+    else:
+        if command == 'access-list-create':
+            if ACC_LIST_EXISTS is True:
+                module.exit_json(
+                    skipped=True,
+                    msg='access list with name %s already exists' % list_name
+                )
+        cli += ' scope %s ' % scope
+
+    run_cli(module, cli, state_map)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/storage/netapp/na_ontap_cluster_peer.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_cluster_peer.py
@@ -23,14 +23,16 @@ options:
     description:
       - Whether the specified cluster peer should exist or not.
     default: present
-  source_intercluster_lif:
+  source_intercluster_lifs:
     description:
-      - Intercluster address of the source cluster.
-      - Used as peer-address in destination cluster.
-  dest_intercluster_lif:
+      - Intercluster addresses of the source cluster.
+      - Used as peer-addresses in destination cluster.
+    version_added: "2.8"
+  dest_intercluster_lifs:
     description:
-      - Intercluster address of the destination cluster.
-      - Used as peer-address in source cluster.
+      - Intercluster addresses of the destination cluster.
+      - Used as peer-addresses in source cluster.
+    version_added: "2.8"
   passphrase:
     description:
       - The arbitrary passphrase that matches the one given to the peer cluster.
@@ -57,16 +59,18 @@ version_added: "2.7"
 '''
 
 EXAMPLES = """
+
     - name: Create cluster peer
       na_ontap_cluster_peer:
         state: present
-        source_intercluster_lif: 1.2.3.4
-        dest_intercluster_lif: 5.6.7.8
+        source_intercluster_lifs: 1.2.3.4,1.2.3.5
+        dest_intercluster_lifs: 1.2.3.6,1.2.3.7
         passphrase: XXXX
         hostname: "{{ netapp_hostname }}"
         username: "{{ netapp_username }}"
         password: "{{ netapp_password }}"
         dest_hostname: "{{ dest_netapp_hostname }}"
+
     - name: Delete cluster peer
       na_ontap_cluster_peer:
         state: absent
@@ -100,8 +104,8 @@ class NetAppONTAPClusterPeer(object):
         self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
         self.argument_spec.update(dict(
             state=dict(required=False, type='str', choices=['present', 'absent'], default='present'),
-            source_intercluster_lif=dict(required=False, type='str'),
-            dest_intercluster_lif=dict(required=False, type='str'),
+            source_intercluster_lifs=dict(required=False, type='list'),
+            dest_intercluster_lifs=dict(required=False, type='list'),
             passphrase=dict(required=False, type='str', no_log=True),
             dest_hostname=dict(required=True, type='str'),
             dest_username=dict(required=False, type='str'),
@@ -112,7 +116,7 @@ class NetAppONTAPClusterPeer(object):
 
         self.module = AnsibleModule(
             argument_spec=self.argument_spec,
-            required_together=[['source_intercluster_lif', 'dest_intercluster_lif', 'passphrase']],
+            required_together=[['source_intercluster_lifs', 'dest_intercluster_lifs', 'passphrase']],
             required_if=[('state', 'absent', ['source_cluster_name', 'dest_cluster_name'])],
             supports_check_mode=True
         )
@@ -131,6 +135,8 @@ class NetAppONTAPClusterPeer(object):
             if self.parameters.get('dest_password'):
                 self.module.params['password'] = self.parameters['dest_password']
             self.dest_server = netapp_utils.setup_na_ontap_zapi(module=self.module)
+            # reset to source host connection for asup logs
+            self.module.params['hostname'] = self.parameters['hostname']
 
     def cluster_peer_get_iter(self, cluster):
         """
@@ -142,12 +148,13 @@ class NetAppONTAPClusterPeer(object):
         query = netapp_utils.zapi.NaElement('query')
         cluster_peer_info = netapp_utils.zapi.NaElement('cluster-peer-info')
         if cluster == 'source':
-            peer_lif, peer_cluster = 'dest_intercluster_lif', 'dest_cluster_name'
+            peer_lifs, peer_cluster = 'dest_intercluster_lifs', 'dest_cluster_name'
         else:
-            peer_lif, peer_cluster = 'source_intercluster_lif', 'source_cluster_name'
-        peer_addresses = netapp_utils.zapi.NaElement('peer-addresses')
-        if self.parameters.get(peer_lif):
-            peer_addresses.add_new_child('remote-inet-address', self.parameters[peer_lif])
+            peer_lifs, peer_cluster = 'source_intercluster_lifs', 'source_cluster_name'
+        if self.parameters.get(peer_lifs):
+            peer_addresses = netapp_utils.zapi.NaElement('peer-addresses')
+            for peer in self.parameters.get(peer_lifs):
+                peer_addresses.add_new_child('remote-inet-address', peer)
             cluster_peer_info.add_child_elem(peer_addresses)
         if self.parameters.get(peer_cluster):
             cluster_peer_info.add_new_child('cluster-name', self.parameters[peer_cluster])
@@ -206,7 +213,7 @@ class NetAppONTAPClusterPeer(object):
     def cluster_peer_create(self, cluster):
         """
         Create a cluster peer on source or destination
-        For source cluster, peer address = destination inter-cluster LIF and vice-versa
+        For source cluster, peer addresses = destination inter-cluster LIFs and vice-versa
         :param cluster: type of cluster (source or destination)
         :return: None
         """
@@ -214,10 +221,11 @@ class NetAppONTAPClusterPeer(object):
             'cluster-peer-create', **{'passphrase': self.parameters['passphrase']})
         peer_addresses = netapp_utils.zapi.NaElement('peer-addresses')
         if cluster == 'source':
-            server, peer_address = self.server, self.parameters['dest_intercluster_lif']
+            server, peer_address = self.server, self.parameters['dest_intercluster_lifs']
         else:
-            server, peer_address = self.dest_server, self.parameters['source_intercluster_lif']
-        peer_addresses.add_new_child('remote-inet-address', peer_address)
+            server, peer_address = self.dest_server, self.parameters['source_intercluster_lifs']
+        for each in peer_address:
+            peer_addresses.add_new_child('remote-inet-address', each)
         cluster_peer_create.add_child_elem(peer_addresses)
         try:
             server.invoke_successfully(cluster_peer_create, enable_tunneling=True)
@@ -231,6 +239,9 @@ class NetAppONTAPClusterPeer(object):
         Apply action to cluster peer
         :return: None
         """
+        results = netapp_utils.get_cserver(self.server)
+        cserver = netapp_utils.setup_na_ontap_zapi(module=self.module, vserver=results)
+        netapp_utils.ems_log_event("na_ontap_cluster_peer", cserver)
         source = self.cluster_peer_get('source')
         destination = self.cluster_peer_get('destination')
         source_action = self.na_helper.get_cd_action(source, self.parameters)

--- a/lib/ansible/plugins/action/ce.py
+++ b/lib/ansible/plugins/action/ce.py
@@ -1,21 +1,8 @@
 #
-# (c) 2016 Red Hat Inc.
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# Copyright: (c) 2016, Red Hat Inc.
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
@@ -83,7 +70,7 @@ class ActionModule(_ActionModule):
         elif self._play_context.connection in ('netconf', 'network_cli'):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
-                display.warning('provider is unnessary whene using %s and will be ignored' % self._play_context.connection)
+                display.warning('provider is unnecessary when using %s and will be ignored' % self._play_context.connection)
                 del self._task.args['provider']
 
             if (self._play_context.connection == 'network_cli' and self._task.action not in CLI_SUPPORTED_MODULES) or \
@@ -93,7 +80,7 @@ class ActionModule(_ActionModule):
 
         if (self._play_context.connection == 'local' and transport == 'cli' and self._task.action in CLI_SUPPORTED_MODULES) \
                 or self._play_context.connection == 'network_cli':
-            # make sure we are in the right cli context whitch should be
+            # make sure we are in the right cli context which should be
             # enable mode and not config module
             if socket_path is None:
                 socket_path = self._connection.socket_path

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -56,7 +56,7 @@ class ActionModule(ActionBase):
     SHUTDOWN_COMMAND_ARGS = {
         'linux': '-r {delay_min} "{message}"',
         'freebsd': '-r +{delay_sec}s "{message}"',
-        'sunos': '-y -g {delay_sec} -r "{message}"',
+        'sunos': '-i 6 -y -g {delay_sec} "{message}"',
         'darwin': '-r +{delay_min} "{message}"',
         'openbsd': '-r +{delay_min} "{message}"',
     }

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -302,7 +302,7 @@ class Connection(ConnectionBase):
             raise AnsibleError("paramiko is not installed")
 
         port = self._play_context.port or 22
-        display.vvv("ESTABLISH CONNECTION FOR USER: %s on PORT %s TO %s" % (self._play_context.remote_user, port, self._play_context.remote_addr),
+        display.vvv("ESTABLISH PARAMIKO SSH CONNECTION FOR USER: %s on PORT %s TO %s" % (self._play_context.remote_user, port, self._play_context.remote_addr),
                     host=self._play_context.remote_addr)
 
         ssh = paramiko.SSHClient()

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -156,8 +156,10 @@ options:
 
 import base64
 import json
+import logging
 import os
 
+from ansible import constants as C
 from ansible.errors import AnsibleConnectionFailure, AnsibleError
 from ansible.errors import AnsibleFileNotFound
 from ansible.module_utils.parsing.convert_bool import boolean
@@ -203,6 +205,11 @@ class Connection(ConnectionBase):
 
         self._shell_type = 'powershell'
         super(Connection, self).__init__(*args, **kwargs)
+
+        if not C.DEFAULT_DEBUG:
+            logging.getLogger('pypsrp').setLevel(logging.INFO)
+            logging.getLogger('requests_credssp').setLevel(logging.INFO)
+            logging.getLogger('urllib3').setLevel(logging.INFO)
 
     def _connect(self):
         if not HAS_PYPSRP:

--- a/lib/ansible/plugins/connection/saltstack.py
+++ b/lib/ansible/plugins/connection/saltstack.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = """
-    author: Michael Scherer <misc@zarb.org>
+    author: Michael Scherer (@mscherer) <misc@zarb.org>
     connection: saltstack
     short_description: Allow ansible to piggyback on salt minions
     description:

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -97,6 +97,7 @@ DOCUMENTATION = """
 """
 
 import base64
+import logging
 import os
 import re
 import traceback
@@ -112,6 +113,7 @@ try:
 except ImportError:
     pass
 
+from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleConnectionFailure
 from ansible.errors import AnsibleFileNotFound
 from ansible.module_utils.parsing.convert_bool import boolean
@@ -190,6 +192,11 @@ class Connection(ConnectionBase):
         self._shell_type = 'powershell'
 
         super(Connection, self).__init__(*args, **kwargs)
+
+        if not C.DEFAULT_DEBUG:
+            logging.getLogger('requests_credssp').setLevel(logging.INFO)
+            logging.getLogger('requests_kerberos').setLevel(logging.INFO)
+            logging.getLogger('urllib3').setLevel(logging.INFO)
 
     def _build_winrm_kwargs(self):
         # this used to be in set_options, as win_reboot needs to be able to
@@ -365,7 +372,7 @@ class Connection(ConnectionBase):
 
         winrm_host = self._winrm_host
         if HAS_IPADDRESS:
-            display.vvvv("checking if winrm_host %s is an IPv6 address" % winrm_host)
+            display.debug("checking if winrm_host %s is an IPv6 address" % winrm_host)
             try:
                 ipaddress.IPv6Address(winrm_host)
             except ipaddress.AddressValueError:

--- a/lib/ansible/plugins/lookup/dnstxt.py
+++ b/lib/ansible/plugins/lookup/dnstxt.py
@@ -84,6 +84,8 @@ class LookupModule(LookupBase):
                 string = 'NXDOMAIN'
             except dns.resolver.Timeout:
                 string = ''
+            except dns.resolver.NoAnswer:
+                string = ''
             except DNSException as e:
                 raise AnsibleError("dns.resolver unhandled exception %s" % to_native(e))
 

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -402,7 +402,7 @@ class StrategyBase:
 
         def parent_handler_match(target_handler, handler_name):
             if target_handler:
-                if isinstance(target_handler, (TaskInclude, IncludeRole)):
+                if isinstance(target_handler, (TaskInclude, IncludeRole)) and not getattr(target_handler, 'statically_loaded', True):
                     try:
                         handler_vars = self._variable_manager.get_vars(play=iterator._play, task=target_handler)
                         templar = Templar(loader=self._loader, variables=handler_vars)

--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -107,7 +107,7 @@ class AnsibleJ2Vars(Mapping):
             except AnsibleUndefinedVariable:
                 raise
             except Exception as e:
-                msg = getattr(e, 'message') or to_native(e)
+                msg = getattr(e, 'message', None) or to_native(e)
                 raise AnsibleError("An unhandled exception occurred while templating '%s'. "
                                    "Error was a %s, original message: %s" % (to_native(variable), type(e), msg))
 

--- a/test/integration/targets/acme_inspect/aliases
+++ b/test/integration/targets/acme_inspect/aliases
@@ -1,0 +1,2 @@
+shippable/cloud/group1
+cloud/acme

--- a/test/integration/targets/acme_inspect/meta/main.yml
+++ b/test/integration/targets/acme_inspect/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_acme

--- a/test/integration/targets/acme_inspect/tasks/impl.yml
+++ b/test/integration/targets/acme_inspect/tasks/impl.yml
@@ -1,0 +1,150 @@
+---
+- name: Generate account key
+  command: openssl ecparam -name prime256v1 -genkey -out {{ output_dir }}/accountkey.pem
+
+- name: Parse account key (to ease debugging some test failures)
+  command: openssl ec -in {{ output_dir }}/accountkey.pem -noout -text
+
+- name: Get directory
+  acme_inspect:
+    acme_directory: https://{{ acme_host }}:14000/dir
+    acme_version: 2
+    validate_certs: no
+    method: directory-only
+  register: directory
+- debug: var=directory
+
+- name: Create an account
+  acme_inspect:
+    acme_directory: https://{{ acme_host }}:14000/dir
+    acme_version: 2
+    validate_certs: no
+    account_key_src: "{{ output_dir }}/accountkey.pem"
+    url: "{{ directory.directory.newAccount}}"
+    method: post
+    content: '{"termsOfServiceAgreed":true}'
+  register: account_creation
+  # account_creation.headers.location contains the account URI
+  # if creation was successful
+- debug: var=account_creation
+
+- name: Get account information
+  acme_inspect:
+    acme_directory: https://{{ acme_host }}:14000/dir
+    acme_version: 2
+    validate_certs: no
+    account_key_src: "{{ output_dir }}/accountkey.pem"
+    account_uri: "{{ account_creation.headers.location }}"
+    url: "{{ account_creation.headers.location }}"
+    method: get
+  register: account_get
+- debug: var=account_get
+
+- name: Update account contacts
+  acme_inspect:
+    acme_directory: https://{{ acme_host }}:14000/dir
+    acme_version: 2
+    validate_certs: no
+    account_key_src: "{{ output_dir }}/accountkey.pem"
+    account_uri: "{{ account_creation.headers.location }}"
+    url: "{{ account_creation.headers.location }}"
+    method: post
+    content: '{{ account_info | to_json }}'
+  vars:
+    account_info:
+      # For valid values, see
+      # https://tools.ietf.org/html/draft-ietf-acme-acme-16#section-7.3
+      contact:
+      - mailto:me@example.com
+  register: account_update
+- debug: var=account_update
+
+- name: Create certificate order
+  acme_inspect:
+    acme_directory: https://{{ acme_host }}:14000/dir
+    acme_version: 2
+    validate_certs: no
+    account_key_src: "{{ output_dir }}/accountkey.pem"
+    account_uri: "{{ account_creation.headers.location }}"
+    url: "{{ directory.directory.newOrder }}"
+    method: post
+    content: '{{ create_order | to_json }}'
+  vars:
+    create_order:
+      # For valid values, see
+      # https://tools.ietf.org/html/draft-ietf-acme-acme-16#section-7.4
+      identifiers:
+      - type: dns
+        value: example.com
+      - type: dns
+        value: example.org
+  register: new_order
+- debug: var=new_order
+
+- name: Get order information
+  acme_inspect:
+    acme_directory: https://{{ acme_host }}:14000/dir
+    acme_version: 2
+    validate_certs: no
+    account_key_src: "{{ output_dir }}/accountkey.pem"
+    account_uri: "{{ account_creation.headers.location }}"
+    url: "{{ new_order.headers.location }}"
+    method: get
+  register: order
+- debug: var=order
+
+- name: Get authzs for order
+  acme_inspect:
+    acme_directory: https://{{ acme_host }}:14000/dir
+    acme_version: 2
+    validate_certs: no
+    account_key_src: "{{ output_dir }}/accountkey.pem"
+    account_uri: "{{ account_creation.headers.location }}"
+    url: "{{ item }}"
+    method: get
+  loop: "{{ order.output_json.authorizations }}"
+  register: authz
+- debug: var=authz
+
+- name: Get HTTP-01 challenge for authz
+  acme_inspect:
+    acme_directory: https://{{ acme_host }}:14000/dir
+    acme_version: 2
+    validate_certs: no
+    account_key_src: "{{ output_dir }}/accountkey.pem"
+    account_uri: "{{ account_creation.headers.location }}"
+    url: "{{ (item.challenges | selectattr('type', 'equalto', 'http-01') | list)[0].url }}"
+    method: get
+  register: http01challenge
+  loop: "{{ authz.results | map(attribute='output_json') | list }}"
+- debug: var=http01challenge
+
+- name: Activate HTTP-01 challenge manually
+  acme_inspect:
+    acme_directory: https://{{ acme_host }}:14000/dir
+    acme_version: 2
+    validate_certs: no
+    account_key_src: "{{ output_dir }}/accountkey.pem"
+    account_uri: "{{ account_creation.headers.location }}"
+    url: "{{ item.url }}"
+    method: post
+    content: '{}'
+  register: activation
+  loop: "{{ http01challenge.results | map(attribute='output_json') | list }}"
+- debug: var=activation
+
+- name: Get HTTP-01 challenge results
+  acme_inspect:
+    acme_directory: https://{{ acme_host }}:14000/dir
+    acme_version: 2
+    validate_certs: no
+    account_key_src: "{{ output_dir }}/accountkey.pem"
+    account_uri: "{{ account_creation.headers.location }}"
+    url: "{{ item.url }}"
+    method: get
+  register: validation_result
+  loop: "{{ http01challenge.results | map(attribute='output_json') | list }}"
+  until: "validation_result.output_json.status != 'pending'"
+  retries: 20
+  delay: 1
+- debug: var=validation_result

--- a/test/integration/targets/acme_inspect/tasks/main.yml
+++ b/test/integration/targets/acme_inspect/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+- block:
+  - name: Running tests with OpenSSL backend
+    include_tasks: impl.yml
+    vars:
+      select_crypto_backend: openssl
+
+  - import_tasks: ../tests/validate.yml
+
+  # Old 0.9.8 versions have insufficient CLI support for signing with EC keys
+  when: openssl_version.stdout is version('1.0.0', '>=')
+
+- name: Remove output directory
+  file:
+    path: "{{ output_dir }}"
+    state: absent
+
+- name: Re-create output directory
+  file:
+    path: "{{ output_dir }}"
+    state: directory
+
+- block:
+  - name: Running tests with cryptography backend
+    include_tasks: impl.yml
+    vars:
+      select_crypto_backend: cryptography
+
+  - import_tasks: ../tests/validate.yml
+
+  when: cryptography_version.stdout is version('1.5', '>=')

--- a/test/integration/targets/acme_inspect/tests/validate.yml
+++ b/test/integration/targets/acme_inspect/tests/validate.yml
@@ -1,0 +1,131 @@
+---
+- name: Check directory output
+  assert:
+    that:
+    - directory is not changed
+    - "'directory' in directory"
+    - "'newAccount' in directory.directory"
+    - "'newOrder' in directory.directory"
+    - "'newNonce' in directory.directory"
+    - "'headers' not in directory"
+    - "'output_text' not in directory"
+    - "'output_json' not in directory"
+
+- name: Check account creation output
+  assert:
+    that:
+    - account_creation is changed
+    - "'directory' in account_creation"
+    - "'headers' in account_creation"
+    - "'output_text' in account_creation"
+    - "'output_json' in account_creation"
+    - account_creation.headers.status == 201
+    - "'location' in account_creation.headers"
+    - account_creation.output_json.status == 'valid'
+    - not account_creation.output_json.contact
+    - account_creation.output_text | from_json == account_creation.output_json
+
+- name: Check account get output
+  assert:
+    that:
+    - account_get is not changed
+    - "'directory' in account_get"
+    - "'headers' in account_get"
+    - "'output_text' in account_get"
+    - "'output_json' in account_get"
+    - account_get.headers.status == 200
+    - account_get.output_json == account_creation.output_json
+
+- name: Check account update output
+  assert:
+    that:
+    - account_update is changed
+    - "'directory' in account_update"
+    - "'headers' in account_update"
+    - "'output_text' in account_update"
+    - "'output_json' in account_update"
+    - account_update.output_json.status == 'valid'
+    - account_update.output_json.contact | length == 1
+    - account_update.output_json.contact[0] == 'mailto:me@example.com'
+
+- name: Check certificate request output
+  assert:
+    that:
+    - new_order is changed
+    - "'directory' in new_order"
+    - "'headers' in new_order"
+    - "'output_text' in new_order"
+    - "'output_json' in new_order"
+    - new_order.output_json.authorizations | length == 2
+    - new_order.output_json.identifiers | length == 2
+    - new_order.output_json.status == 'pending'
+    - "'finalize' in new_order.output_json"
+
+- name: Check get order output
+  assert:
+    that:
+    - order is not changed
+    - "'directory' in order"
+    - "'headers' in order"
+    - "'output_text' in order"
+    - "'output_json' in order"
+    # The order of identifiers and authorizations is randomized!
+    # - new_order.output_json == order.output_json
+
+- name: Check get authz output
+  assert:
+    that:
+    - item is not changed
+    - "'directory' in item"
+    - "'headers' in item"
+    - "'output_text' in item"
+    - "'output_json' in item"
+    - item.output_json.challenges | length >= 3
+    - item.output_json.identifier.type == 'dns'
+    - item.output_json.status == 'pending'
+  loop: "{{ authz.results }}"
+
+- name: Check get challenge output
+  assert:
+    that:
+    - item is not changed
+    - "'directory' in item"
+    - "'headers' in item"
+    - "'output_text' in item"
+    - "'output_json' in item"
+    - item.output_json.status == 'pending'
+    - item.output_json.type == 'http-01'
+    - item.output_json.url == item.invocation.module_args.url
+    - "'token' in item.output_json"
+  loop: "{{ http01challenge.results }}"
+
+- name: Check challenge activation output
+  assert:
+    that:
+    - item is changed
+    - "'directory' in item"
+    - "'headers' in item"
+    - "'output_text' in item"
+    - "'output_json' in item"
+    - item.output_json.status == 'pending'
+    - item.output_json.type == 'http-01'
+    - item.output_json.url == item.invocation.module_args.url
+    - "'token' in item.output_json"
+  loop: "{{ activation.results }}"
+
+- name: Check validation result
+  assert:
+    that:
+    - item is not changed
+    - "'directory' in item"
+    - "'headers' in item"
+    - "'output_text' in item"
+    - "'output_json' in item"
+    - item.output_json.status == 'invalid'
+    - item.output_json.type == 'http-01'
+    - item.output_json.url == item.invocation.module_args.url
+    - "'token' in item.output_json"
+    - "'validated' in item.output_json"
+    - "'error' in item.output_json"
+    - item.output_json.error.type == 'urn:ietf:params:acme:error:unauthorized'
+  loop: "{{ validation_result.results }}"

--- a/test/integration/targets/ec2_launch_template/aliases
+++ b/test/integration/targets/ec2_launch_template/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+unsupported

--- a/test/integration/targets/ec2_launch_template/playbooks/full_test.yml
+++ b/test/integration/targets/ec2_launch_template/playbooks/full_test.yml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  connection: local
+  roles:
+    - ec2_launch_template

--- a/test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/defaults/main.yml
+++ b/test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+resource_prefix: ansible-test-default-group
+ec2_ami_image:
+  # https://wiki.centos.org/Cloud/AWS collected 2018-01-10
+  ap-northeast-1: ami-571e3c30
+  ap-northeast-2: ami-97cb19f9
+  ap-south-1: ami-11f0837e
+  ap-southeast-1: ami-30318f53
+  ap-southeast-2: ami-24959b47
+  ca-central-1: ami-daeb57be
+  eu-central-1: ami-7cbc6e13
+  eu-west-1: ami-0d063c6b
+  eu-west-2: ami-c22236a6
+  sa-east-1: ami-864f2dea
+  us-east-1: ami-ae7bfdb8
+  us-east-2: ami-9cbf9bf9
+  us-west-1: ami-7c280d1c
+  us-west-2: ami-0c2aba6c

--- a/test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/files/assume-role-policy.json
+++ b/test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/files/assume-role-policy.json
@@ -1,0 +1,13 @@
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/meta/main.yml
+++ b/test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/tasks/cpu_options.yml
+++ b/test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/tasks/cpu_options.yml
@@ -1,0 +1,38 @@
+- block:
+  - name: delete a non-existent template
+    ec2_launch_template:
+      name: "{{ resource_prefix }}-not-a-real-template"
+      state: absent
+    register: del_fake_lt
+    ignore_errors: true
+  - assert:
+      that:
+        - del_fake_lt is not failed
+  - name: create c4.large instance with cpu_options
+    ec2_launch_template:
+      name: "{{ resource_prefix }}-c4large-1-threads-per-core"
+      image_id: "{{ ec2_ami_image[aws_region] }}"
+      tags:
+        TestId: "{{ resource_prefix }}"
+      instance_type: c4.large
+      cpu_options:
+          core_count: 1
+          threads_per_core: 1
+    register: lt
+
+  - name: instance with cpu_options created with the right options
+    assert:
+      that:
+        - lt is success
+        - lt is changed
+        - "lt.latest_template.launch_template_data.cpu_options.core_count == 1"
+        - "lt.latest_template.launch_template_data.cpu_options.threads_per_core == 1"
+  always:
+  - name: delete the template
+    ec2_launch_template:
+      name: "{{ resource_prefix }}-c4large-1-threads-per-core"
+      state: absent
+    register: del_lt
+    retries: 10
+    until: del_lt is not failed
+    ignore_errors: true

--- a/test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/tasks/iam_instance_role.yml
+++ b/test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/tasks/iam_instance_role.yml
@@ -1,0 +1,104 @@
+- block:
+    - name: Create IAM role for test
+      iam_role:
+        name: "{{ resource_prefix }}-test-policy"
+        assume_role_policy_document: "{{ lookup('file','assume-role-policy.json') }}"
+        state: present
+        create_instance_profile: yes
+        managed_policy:
+        - AmazonS3ReadOnlyAccess
+      register: iam_role
+
+    - name: Create second IAM role for test
+      iam_role:
+        name: "{{ resource_prefix }}-test-policy-2"
+        assume_role_policy_document: "{{ lookup('file','assume-role-policy.json') }}"
+        state: present
+        create_instance_profile: yes
+        managed_policy:
+        - AmazonS3ReadOnlyAccess
+      register: iam_role_2
+
+    - name: Make instance with an instance_role
+      ec2_launch_template:
+        name: "{{ resource_prefix }}-test-instance-role"
+        image_id: "{{ ec2_ami_image[aws_region] }}"
+        instance_type: t2.micro
+        iam_instance_profile: "{{ resource_prefix }}-test-policy"
+      register: template_with_role
+
+    - assert:
+        that:
+          - 'template_with_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role.arn.replace(":role/", ":instance-profile/")'
+
+    - name: Create template again, with no change to instance_role
+      ec2_launch_template:
+        name: "{{ resource_prefix }}-test-instance-role"
+        image_id: "{{ ec2_ami_image[aws_region] }}"
+        instance_type: t2.micro
+        iam_instance_profile: "{{ resource_prefix }}-test-policy"
+      register: template_with_role
+
+    - assert:
+        that:
+          - 'template_with_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role.arn.replace(":role/", ":instance-profile/")'
+          - 'template_with_role is not changed'
+
+    - name: Update instance with new instance_role
+      ec2_launch_template:
+        name: "{{ resource_prefix }}-test-instance-role"
+        image_id: "{{ ec2_ami_image[aws_region] }}"
+        instance_type: t2.micro
+        iam_instance_profile: "{{ resource_prefix }}-test-policy-2"
+      register: template_with_updated_role
+
+    - assert:
+        that:
+          - 'template_with_updated_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role_2.arn.replace(":role/", ":instance-profile/")'
+          - 'template_with_updated_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role_2.arn.replace(":role/", ":instance-profile/")'
+          - 'template_with_role.default_template.version_number < template_with_updated_role.default_template.version_number'
+          - 'template_with_updated_role is changed'
+          - 'template_with_updated_role is not failed'
+
+    - name: Re-set with same new instance_role
+      ec2_launch_template:
+        name: "{{ resource_prefix }}-test-instance-role"
+        image_id: "{{ ec2_ami_image[aws_region] }}"
+        instance_type: t2.micro
+        iam_instance_profile: "{{ resource_prefix }}-test-policy-2"
+      register: template_with_updated_role
+
+    - assert:
+        that:
+          - 'template_with_updated_role is not changed'
+          - 'template_with_updated_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role_2.arn.replace(":role/", ":instance-profile/")'
+
+  always:
+    - name: delete launch template
+      ec2_launch_template:
+        name: "{{ resource_prefix }}-test-instance-role"
+        state: absent
+      register: lt_removed
+      until: lt_removed is not failed
+      ignore_errors: yes
+      retries: 10
+    - name: Delete IAM role for test
+      iam_role:
+        name: "{{ resource_prefix }}-test-policy"
+        assume_role_policy_document: "{{ lookup('file','assume-role-policy.json') }}"
+        state: absent
+        create_instance_profile: yes
+      register: iam_removed
+      until: iam_removed is not failed
+      ignore_errors: yes
+      retries: 10
+    - name: Delete IAM role for test
+      iam_role:
+        name: "{{ resource_prefix }}-test-policy-2"
+        assume_role_policy_document: "{{ lookup('file','assume-role-policy.json') }}"
+        state: absent
+        create_instance_profile: yes
+      register: iam_2_removed
+      until: iam_2_removed is not failed
+      ignore_errors: yes
+      retries: 10

--- a/test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/tasks/main.yml
+++ b/test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+# A Note about ec2 environment variable name preference:
+#  - EC2_URL -> AWS_URL
+#  - EC2_ACCESS_KEY -> AWS_ACCESS_KEY_ID -> AWS_ACCESS_KEY
+#  - EC2_SECRET_KEY -> AWS_SECRET_ACCESS_KEY -> AWX_SECRET_KEY
+#  - EC2_REGION -> AWS_REGION
+#
+
+# - include: ../../../../../setup_ec2/tasks/common.yml module_name: ec2_instance
+
+- module_defaults:
+    group/aws:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token }}"
+      region: "{{ aws_region }}"
+  block:
+    - include_tasks: cpu_options.yml
+    - include_tasks: iam_instance_role.yml
+
+  always:
+  - debug:
+      msg: teardown goes here

--- a/test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/tasks/tags_and_vpc_settings.yml
+++ b/test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/tasks/tags_and_vpc_settings.yml
@@ -1,0 +1,216 @@
+- block:
+  # ============================================================
+  # set up VPC
+  - name: Create VPC for use in testing
+    ec2_vpc_net:
+      name: "{{ resource_prefix }}-vpc"
+      cidr_block: 10.99.0.0/16
+      tags:
+        Name: Ansible ec2_instance Testing VPC
+      tenancy: default
+    register: testing_vpc
+
+  - name: Create default subnet in zone A
+    ec2_vpc_subnet:
+      state: present
+      vpc_id: "{{ testing_vpc.vpc.id }}"
+      cidr: 10.99.0.0/24
+      az: "{{ aws_region }}a"
+      resource_tags:
+        Name: "{{ resource_prefix }}-subnet-a"
+    register: testing_subnet_a
+
+  - name: Create secondary subnet in zone B
+    ec2_vpc_subnet:
+      state: present
+      vpc_id: "{{ testing_vpc.vpc.id }}"
+      cidr: 10.99.1.0/24
+      az: "{{ aws_region }}b"
+      resource_tags:
+        Name: "{{ resource_prefix }}-subnet-b"
+    register: testing_subnet_b
+
+  - name: create a security group with the vpc
+    ec2_group:
+      name: "{{ resource_prefix }}-sg"
+      description: a security group for ansible tests
+      vpc_id: "{{ testing_vpc.vpc.id }}"
+      rules:
+        - proto: tcp
+          ports: [22, 80]
+          cidr_ip: 0.0.0.0/0
+    register: sg
+    # TODO: switch these tests from instances
+  - assert:
+      that:
+      - 1 == 0
+  # ============================================================
+  # start subnet/sg testing
+  - name: Make instance in the testing subnet created in the test VPC
+    ec2_instance:
+      name: "{{ resource_prefix }}-test-basic-vpc-create"
+      image_id: "{{ ec2_ami_image[aws_region] }}"
+      user_data: |
+        #cloud-config
+        package_upgrade: true
+        package_update: true
+      tags:
+        TestId: "{{ resource_prefix }}"
+        Something: else
+      security_groups: "{{ sg.group_id }}"
+      network:
+        source_dest_check: false
+      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+      instance_type: t2.micro
+      volumes:
+      - device_name: /dev/sda1
+        ebs:
+          delete_on_termination: true
+      <<: *aws_connection_info
+    register: in_test_vpc
+
+  - name: Try to re-make the instance, hopefully this shows changed=False
+    ec2_instance:
+      name: "{{ resource_prefix }}-test-basic-vpc-create"
+      image_id: "{{ ec2_ami_image[aws_region] }}"
+      user_data: |
+        #cloud-config
+        package_upgrade: true
+        package_update: true
+      tags:
+        TestId: "{{ resource_prefix }}"
+        Something: else
+      security_groups: "{{ sg.group_id }}"
+      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+      instance_type: t2.micro
+      <<: *aws_connection_info
+    register: remake_in_test_vpc
+  - name: "Remaking the same instance resulted in no changes"
+    assert:
+      that: not remake_in_test_vpc.changed
+  - name: check that instance IDs match anyway
+    assert:
+      that: 'remake_in_test_vpc.instance_ids[0] == in_test_vpc.instance_ids[0]'
+  - name: check that source_dest_check was set to false
+    assert:
+      that: 'not remake_in_test_vpc.instances[0].source_dest_check'
+
+  - name: Alter it by adding tags
+    ec2_instance:
+      name: "{{ resource_prefix }}-test-basic-vpc-create"
+      image_id: "{{ ec2_ami_image[aws_region] }}"
+      tags:
+        TestId: "{{ resource_prefix }}"
+        Another: thing
+      security_groups: "{{ sg.group_id }}"
+      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+      instance_type: t2.micro
+      <<: *aws_connection_info
+    register: add_another_tag
+
+  - ec2_instance_facts:
+      instance_ids: "{{ add_another_tag.instance_ids }}"
+      <<: *aws_connection_info
+    register: check_tags
+  - name: "Remaking the same instance resulted in no changes"
+    assert:
+      that:
+        - check_tags.instances[0].tags.Another == 'thing'
+        - check_tags.instances[0].tags.Something == 'else'
+  
+  - name: Purge a tag
+    ec2_instance:
+      name: "{{ resource_prefix }}-test-basic-vpc-create"
+      image_id: "{{ ec2_ami_image[aws_region] }}"
+      purge_tags: true
+      tags:
+        TestId: "{{ resource_prefix }}"
+        Another: thing
+      security_groups: "{{ sg.group_id }}"
+      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+      instance_type: t2.micro
+      <<: *aws_connection_info
+  - ec2_instance_facts:
+      instance_ids: "{{ add_another_tag.instance_ids }}"
+      <<: *aws_connection_info
+    register: check_tags
+  - name: "Remaking the same instance resulted in no changes"
+    assert:
+      that:
+        - "'Something' not in check_tags.instances[0].tags"
+
+  - name: Terminate instance
+    ec2_instance:
+      filters:
+        tag:TestId: "{{ resource_prefix }}"
+      state: absent
+      <<: *aws_connection_info
+    register: result
+  - assert:
+      that: result.changed
+
+  - name: Terminate instance
+    ec2_instance:
+      instance_ids: "{{ in_test_vpc.instance_ids }}"
+      state: absent
+      <<: *aws_connection_info
+    register: result
+  - assert:
+      that: not result.changed
+
+  - name: check that subnet-default public IP rule was followed
+    assert:
+      that:
+        - in_test_vpc.instances[0].public_dns_name == ""
+        - in_test_vpc.instances[0].private_ip_address.startswith("10.22.33")
+        - in_test_vpc.instances[0].subnet_id == testing_subnet_b.subnet.id
+  - name: check that tags were applied
+    assert:
+      that:
+        - in_test_vpc.instances[0].tags.Name.startswith(resource_prefix)
+        - in_test_vpc.instances[0].state.name == 'running'
+
+  always:
+  - name: remove the security group
+    ec2_group:
+      name: "{{ resource_prefix }}-sg"
+      description: a security group for ansible tests
+      vpc_id: "{{ testing_vpc.vpc.id }}"
+      state: absent
+    register: removed
+    until: removed is not failed
+    ignore_errors: yes
+    retries: 10
+
+  - name: remove subnet A
+    ec2_vpc_subnet:
+      state: absent
+      vpc_id: "{{ testing_vpc.vpc.id }}"
+      cidr: 10.99.0.0/24
+    register: removed
+    until: removed is not failed
+    ignore_errors: yes
+    retries: 10
+
+  - name: remove subnet B
+    ec2_vpc_subnet:
+      state: absent
+      vpc_id: "{{ testing_vpc.vpc.id }}"
+      cidr: 10.99.1.0/24
+    register: removed
+    until: removed is not failed
+    ignore_errors: yes
+    retries: 10
+
+  - name: remove the VPC
+    ec2_vpc_net:
+      name: "{{ resource_prefix }}-vpc"
+      cidr_block: 10.99.0.0/16
+      state: absent
+      tags:
+        Name: Ansible Testing VPC
+      tenancy: default
+    register: removed
+    until: removed is not failed
+    ignore_errors: yes
+    retries: 10

--- a/test/integration/targets/ec2_launch_template/playbooks/version_fail.yml
+++ b/test/integration/targets/ec2_launch_template/playbooks/version_fail.yml
@@ -1,0 +1,35 @@
+- hosts: localhost
+  connection: local
+  vars:
+     resource_prefix: 'ansible-testing'
+  module_defaults:
+    group/aws:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token }}"
+      region: "{{ aws_region }}"
+  tasks:
+    - block:
+        - name: Include vars file in roles/ec2_instance/defaults/main.yml
+          include_vars:
+            file: 'roles/ec2_launch_template/defaults/main.yml'
+
+        - name: create c4.large template (failure expected)
+          ec2_launch_template:
+            state: present
+            name: "ansible-test-{{ resource_prefix | regex_search('([0-9]+)$') }}-tpl"
+            instance_type: c4.large
+          register: ec2_lt
+          ignore_errors: yes
+
+        - name: check that graceful error message is returned when creation with cpu_options and old botocore 
+          assert:
+            that:
+              - ec2_lt is failed
+              - 'ec2_lt.msg == "ec2_launch_template requires boto3 >= 1.6.0"'
+      always:
+        - name: delete the c4.large template just in case it was created
+          ec2_launch_template:
+            state: absent
+            name: "ansible-test-{{ resource_prefix | regex_search('([0-9]+)$') }}-tpl"
+          ignore_errors: yes

--- a/test/integration/targets/ec2_launch_template/runme.sh
+++ b/test/integration/targets/ec2_launch_template/runme.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# We don't set -u here, due to pypa/virtualenv#150
+set -ex
+
+MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
+
+trap 'rm -rf "${MYTMPDIR}"' EXIT
+
+# This is needed for the ubuntu1604py3 tests
+# Ubuntu patches virtualenv to make the default python2
+# but for the python3 tests we need virtualenv to use python3
+PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
+
+# Test graceful failure for older versions of botocore
+export ANSIBLE_ROLES_PATH=../
+virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/boto3-less-than-1.6.0"
+source "${MYTMPDIR}/boto3-less-than-1.6.0/bin/activate"
+"${PYTHON}" -m pip install 'boto3<1.6.0'
+ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/version_fail.yml "$@"
+
+# Run full test suite
+virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/boto3-recent"
+source "${MYTMPDIR}/boto3-recent/bin/activate"
+$PYTHON -m pip install 'boto3>1.6.0'
+ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/full_test.yml "$@"

--- a/test/integration/targets/include_import/handler_addressing/playbook.yml
+++ b/test/integration/targets/include_import/handler_addressing/playbook.yml
@@ -1,0 +1,11 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: include_handler_test
+
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: import_handler_test

--- a/test/integration/targets/include_import/handler_addressing/roles/import_handler_test/handlers/main.yml
+++ b/test/integration/targets/include_import/handler_addressing/roles/import_handler_test/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: do_import
+  import_tasks: tasks/handlers.yml

--- a/test/integration/targets/include_import/handler_addressing/roles/import_handler_test/tasks/handlers.yml
+++ b/test/integration/targets/include_import/handler_addressing/roles/import_handler_test/tasks/handlers.yml
@@ -1,0 +1,2 @@
+- debug:
+    msg: import handler task

--- a/test/integration/targets/include_import/handler_addressing/roles/import_handler_test/tasks/main.yml
+++ b/test/integration/targets/include_import/handler_addressing/roles/import_handler_test/tasks/main.yml
@@ -1,0 +1,3 @@
+- command: "true"
+  notify:
+    - do_import

--- a/test/integration/targets/include_import/handler_addressing/roles/include_handler_test/handlers/main.yml
+++ b/test/integration/targets/include_import/handler_addressing/roles/include_handler_test/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: do_include
+  include_tasks: tasks/handlers.yml

--- a/test/integration/targets/include_import/handler_addressing/roles/include_handler_test/tasks/handlers.yml
+++ b/test/integration/targets/include_import/handler_addressing/roles/include_handler_test/tasks/handlers.yml
@@ -1,0 +1,2 @@
+- debug:
+    msg: include handler task

--- a/test/integration/targets/include_import/handler_addressing/roles/include_handler_test/tasks/main.yml
+++ b/test/integration/targets/include_import/handler_addressing/roles/include_handler_test/tasks/main.yml
@@ -1,0 +1,3 @@
+- command: "true"
+  notify:
+    - do_include

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -86,3 +86,7 @@ ansible-playbook public_exposure/no_overwrite_roles.yml -i ../../inventory "$@"
 
 # https://github.com/ansible/ansible/pull/48068
 ansible-playbook run_once/playbook.yml "$@"
+
+# https://github.com/ansible/ansible/issues/48936
+ansible-playbook -v handler_addressing/playbook.yml 2>&1 | tee test_handler_addressing.out
+test "$(egrep -c 'include handler task|ERROR! The requested handler '"'"'do_import'"'"' was not found' test_handler_addressing.out)" = 2

--- a/test/integration/targets/vmware_dvswitch/tasks/main.yml
+++ b/test/integration/targets/vmware_dvswitch/tasks/main.yml
@@ -78,27 +78,28 @@
 
 
 # Testcase 0002: Add Distributed vSwitch again
-- name: add distributed vSwitch again
-  vmware_dvswitch:
-    validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter_name: "{{ item | basename }}"
-    state: present
-    switch_name: dvswitch_0001
-    mtu: 9000
-    uplink_quantity: 2
-    discovery_proto: lldp
-    discovery_operation: both
-  register: dvs_result_0002
-  with_items:
-    - "{{ datacenters['json'] }}"
-
-- name: ensure distributed vswitch is present
-  assert:
-    that:
-        - "{{ dvs_result_0002.changed == false }}"
+# vcsim doesn't support ldp check (self.dvs.config.linkDiscoveryProtocolConfig.protocol)
+# - name: add distributed vSwitch again
+#   vmware_dvswitch:
+#     validate_certs: False
+#     hostname: "{{ vcsim }}"
+#     username: "{{ vcsim_instance['json']['username'] }}"
+#     password: "{{ vcsim_instance['json']['password'] }}"
+#     datacenter_name: "{{ item | basename }}"
+#     state: present
+#     switch_name: dvswitch_0001
+#     mtu: 9000
+#     uplink_quantity: 2
+#     discovery_proto: lldp
+#     discovery_operation: both
+#   register: dvs_result_0002
+#   with_items:
+#     - "{{ datacenters['json'] }}"
+#
+# - name: ensure distributed vswitch is present
+#   assert:
+#     that:
+#         - "{{ dvs_result_0002.changed == false }}"
 
 
 # FIXME: Uncomment this testcase once vcsim supports distributed vswitch delete method

--- a/test/units/module_utils/test_acme.py
+++ b/test/units/module_utils/test_acme.py
@@ -36,7 +36,7 @@ def test_nopad_b64(value, result):
 
 ################################################
 
-TEST_TEXT = R"""1234
+TEST_TEXT = r"""1234
 5678"""
 
 
@@ -58,7 +58,7 @@ def test_write_file(tmpdir):
 
 TEST_PEM_DERS = [
     (
-        R"""
+        r"""
 -----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIDWajU0PyhYKeulfy/luNtkAve7DkwQ01bXJ97zbxB66oAoGCCqGSM49
 AwEHoUQDQgAEAJz0yAAXAwEmOhTRkjXxwgedbWO6gobYM3lWszrS68G8QSzhXR6A
@@ -83,7 +83,7 @@ def test_pem_to_der(pem, der, tmpdir):
 
 TEST_KEYS = [
     (
-        R"""
+        r"""
 -----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIDWajU0PyhYKeulfy/luNtkAve7DkwQ01bXJ97zbxB66oAoGCCqGSM49
 AwEHoUQDQgAEAJz0yAAXAwEmOhTRkjXxwgedbWO6gobYM3lWszrS68G8QSzhXR6A
@@ -102,7 +102,7 @@ mQ3IzZDimnTTXO7XhVylDT8SLzE44/Epmw==
             'point_size': 32,
             'type': 'ec',
         },
-        R"""
+        r"""
 read EC key
 Private-Key: (256 bit)
 priv:
@@ -146,7 +146,7 @@ if HAS_CURRENT_CRYPTOGRAPHY:
 
 ################################################
 
-TEST_CSR = R"""
+TEST_CSR = r"""
 -----BEGIN NEW CERTIFICATE REQUEST-----
 MIIBJTCBzQIBADAWMRQwEgYDVQQDEwthbnNpYmxlLmNvbTBZMBMGByqGSM49AgEG
 CCqGSM49AwEHA0IABACc9MgAFwMBJjoU0ZI18cIHnW1juoKG2DN5VrM60uvBvEEs
@@ -170,7 +170,7 @@ if HAS_CURRENT_CRYPTOGRAPHY:
 
 ################################################
 
-TEST_CERT = R"""
+TEST_CERT = r"""
 -----BEGIN CERTIFICATE-----
 MIIBljCCATugAwIBAgIBATAKBggqhkjOPQQDAjAWMRQwEgYDVQQDEwthbnNpYmxl
 LmNvbTAeFw0xODExMjUxNTI4MjNaFw0xODExMjYxNTI4MjRaMBYxFDASBgNVBAMT

--- a/test/units/modules/network/ios/fixtures/ios_facts_show_cdp
+++ b/test/units/modules/network/ios/fixtures/ios_facts_show_cdp
@@ -1,0 +1,4 @@
+Global CDP information:
+	Sending CDP packets every 60 seconds
+	Sending a holdtime value of 180 seconds
+	Sending CDPv2 advertisements is  enabled

--- a/test/units/modules/network/ios/fixtures/ios_facts_show_cdp_neighbors_detail
+++ b/test/units/modules/network/ios/fixtures/ios_facts_show_cdp_neighbors_detail
@@ -1,0 +1,40 @@
+-------------------------
+Device ID: R2
+Entry address(es): 
+  IP address: 10.0.0.3
+Platform: cisco CSR1000V,  Capabilities: Router IGMP 
+Interface: GigabitEthernet1,  Port ID (outgoing port): GigabitEthernet2
+Holdtime : 149 sec
+
+Version :
+Cisco IOS Software [Everest], Virtual XE Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 16.6.4, RELEASE SOFTWARE (fc3)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2018 by Cisco Systems, Inc.
+Compiled Sun 08-Jul-18 04:30 by mcpre
+
+advertisement version: 2
+Duplex: full
+Management address(es): 
+  IP address: 10.0.0.3
+
+-------------------------
+Device ID: R3
+Entry address(es): 
+  IP address: 10.0.0.4
+Platform: cisco CSR1000V,  Capabilities: Router IGMP 
+Interface: GigabitEthernet1,  Port ID (outgoing port): GigabitEthernet3
+Holdtime : 149 sec
+
+Version :
+Cisco IOS Software [Everest], Virtual XE Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 16.6.4, RELEASE SOFTWARE (fc3)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2018 by Cisco Systems, Inc.
+Compiled Sun 08-Jul-18 04:30 by mcpre
+
+advertisement version: 2
+Duplex: full
+Management address(es): 
+  IP address: 10.0.0.4
+
+
+Total cdp entries displayed : 2

--- a/test/units/modules/network/ios/fixtures/ios_facts_show_lldp
+++ b/test/units/modules/network/ios/fixtures/ios_facts_show_lldp
@@ -1,0 +1,6 @@
+
+Global LLDP Information:
+    Status: ACTIVE
+    LLDP advertisements are sent every 30 seconds
+    LLDP hold time advertised is 120 seconds
+    LLDP interface reinitialisation delay is 2 seconds

--- a/test/units/modules/network/ios/fixtures/ios_facts_show_lldp_neighbors_detail
+++ b/test/units/modules/network/ios/fixtures/ios_facts_show_lldp_neighbors_detail
@@ -1,0 +1,50 @@
+------------------------------------------------
+Local Intf: Gi1
+Chassis id: 001e.14d4.5300
+Port id: Gi3
+Port Description: GigabitEthernet3
+System Name: R3
+
+System Description: 
+Cisco IOS Software [Everest], Virtual XE Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 16.6.4, RELEASE SOFTWARE (fc3)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2018 by Cisco Systems, Inc.
+Compiled Sun 08-Jul-18 04:30 by 
+
+Time remaining: 116 seconds
+System Capabilities: B,R
+Enabled Capabilities: R
+Management Addresses:
+    IP: 10.0.0.4
+Auto Negotiation - not supported
+Physical media capabilities - not advertised
+Media Attachment Unit type - not advertised
+Vlan ID: - not advertised
+          
+------------------------------------------------
+Local Intf: Gi3
+Chassis id: 001e.e6c9.6d00
+Port id: Gi1
+Port Description: GigabitEthernet1
+System Name: Rtest
+
+System Description: 
+Cisco IOS Software [Everest], Virtual XE Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 16.6.4, RELEASE SOFTWARE (fc3)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2018 by Cisco Systems, Inc.
+Compiled Sun 08-Jul-18 04:30 by 
+
+Time remaining: 116 seconds
+System Capabilities: B,R
+Enabled Capabilities: R
+Management Addresses:
+    IP: 10.3.0.3
+Auto Negotiation - not supported
+Physical media capabilities - not advertised
+Media Attachment Unit type - not advertised
+Vlan ID: - not advertised
+
+
+Total entries displayed: 2
+
+

--- a/test/units/modules/network/ios/test_ios_facts.py
+++ b/test/units/modules/network/ios/test_ios_facts.py
@@ -19,6 +19,7 @@ __metaclass__ = type
 
 from units.compat.mock import patch
 from ansible.modules.network.ios import ios_facts
+from ansible.module_utils.six import assertCountEqual
 from units.modules.utils import set_module_args
 from .ios_module import TestIosModule, load_fixture
 
@@ -86,4 +87,21 @@ class TestIosFactsModule(TestIosModule):
         )
         self.assertEqual(
             result['ansible_facts']['ansible_net_filesystems_info']['bootflash:']['spacefree_kb'], 6453180.0
+        )
+
+    def test_ios_facts_neighbors(self):
+        set_module_args(dict(gather_subset='interfaces'))
+        result = self.execute_module()
+        assertCountEqual(
+            self,
+            result['ansible_facts']['ansible_net_neighbors'].keys(), ['GigabitEthernet1', 'GigabitEthernet3']
+        )
+        assertCountEqual(
+            self,
+            result['ansible_facts']['ansible_net_neighbors']['GigabitEthernet1'],
+            [{'host': 'R2', 'port': 'GigabitEthernet2'}, {'host': 'R3', 'port': 'GigabitEthernet3'}]
+        )
+        assertCountEqual(
+            self,
+            result['ansible_facts']['ansible_net_neighbors']['GigabitEthernet3'], [{'host': 'Rtest', 'port': 'Gi1'}]
         )

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -50,6 +50,7 @@ class BaseTemplar(object):
             some_unsafe_var=wrap_var("unsafe_blip"),
             some_static_unsafe_var=wrap_var("static_unsafe_blip"),
             some_unsafe_keyword=wrap_var("{{ foo }}"),
+            str_with_error="{{ 'str' | from_json }}",
         )
         self.fake_loader = DictDataLoader({
             "/path/to/my_file.txt": "foo\n",
@@ -182,6 +183,10 @@ class TestTemplarTemplate(BaseTemplar, unittest.TestCase):
                                 'template error while templating string',
                                 self.templar.template,
                                 data)
+
+    def test_template_with_error(self):
+        """Check that AnsibleError is raised, fail if an unhandled exception is raised"""
+        self.assertRaises(AnsibleError, self.templar.template, "{{ str_with_error }}")
 
 
 class TestTemplarMisc(BaseTemplar, unittest.TestCase):


### PR DESCRIPTION
##### SUMMARY

The current message to confirm a new vault password reads:

`Confirm vew vault password (%(vault_id)s):`

I changed it to:
`Confirm new vault password (%(vault_id)s):`

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ansible-vault

##### ADDITIONAL INFORMATION

It is very easy to overlook this error and it took me today some minutes to spot the difference in a bash script that I use to create vaulted paswords more easily.

However, I would like this to be fixed so that I can expect the "correct" message in my script and don't have to worry about updating ansible.

As I assume there are other scripts out there for the same purpose, be aware that this might break those scripts but I'd still rather have this typo fixed one time soon than having to worry about when it hits me in the back at some random point in the future.

└─ $: ansible-vault encrypt_string test --vault-id test@prompt

To  test the issue type:
ansible-vault encrypt_string teststring --vault-id test-vault-id@prompt

you are then asked to enter the vault password twice. The message to confirm the vault password reads (old version):

```paste below
New vault password (test-vault-id):
Confirm vew vault password(test-vault-id):
```